### PR TITLE
Add weapon base stat modifiers to CharacterSheetV3 weapon builder and derived stats

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -24,6 +24,24 @@
                 <label class="PrimaryLabel"><span data-i18n="equipped-weapon-accuracy-n">Accuracy</span>: <span name="attr_Equipped_Weapon_Accuracy"></span></label>
                 <label class="PrimaryLabel"><span data-i18n="equipped-weapon-range-n">Range</span>: <span name="attr_Equipped_Weapon_Range"></span></label>
                 <label class="PrimaryLabel"><span data-i18n="equipped-weapon-notes-n">Notes</span>: <span name="attr_Equipped_Weapon_Notes"></span></label>
+                <input type="hidden" name="attr_Equipped_Weapon_Name" value=""/>
+                <input type="hidden" name="attr_Equipped_Weapon_Rune" value=""/>
+                <input type="hidden" name="attr_Equipped_Weapon_Color" value=""/>
+                <input type="hidden" name="attr_Equipped_Weapon_Might" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_Accuracy" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_Critical" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_Range_Min" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_Range_Max" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_DamageType" value="Physical"/>
+                <input type="hidden" name="attr_Equipped_Weapon_STR" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_INT" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_DEX" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_SPD" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_LUK" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_CON" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_WIS" value="0"/>
+                <input type="hidden" name="attr_Equipped_Weapon_Notes" value=""/>
+                <input type="hidden" name="attr_Equipped_Weapon_Type" value=""/>
             </div>
 
             <div class="CharacterEquippedFlexItem"> <!-- Item Selector -->
@@ -34,7 +52,17 @@
                 </fieldset>
                 <label class="PrimaryLabel"><span data-i18n="equipped-item-name-n">Name</span>: <span name="attr_Equipped_Item_Name"></span></label>
                 <label class="PrimaryLabel"><span data-i18n="equipped-item-notes-n">Notes</span>: <span name="attr_Equipped_Item_Notes"></span></label>
-                <input type="hidden" value="" name="attr_Equipped_Item_Name"/>
+                <input type="hidden" name="attr_Equipped_Item_Name" value=""/>
+                <input type="hidden" name="attr_Equipped_Item_Notes" value=""/>
+                <input type="hidden" name="attr_Equipped_Item_HP" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Might" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Accuracy" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Critical" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Dodge" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Avoid" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Defense" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Resistance" value="0"/>
+                <input type="hidden" name="attr_Equipped_Item_Move" value="0"/>
             </div>
         </div>
     </div>
@@ -377,7 +405,77 @@
                         <option value="Gilded Slam" selected="selected" data-i18n="Gilded Slam-Full-Name">Gilded Slam</option>
                         <option value="Orichalcum Slam" selected="selected" data-i18n="Orichalcum Slam-Full-Name">Orichalcum Slam</option>
                     </select></label>
-                    <!-- ToDo: Finish Weapon Section -->
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Rune-Label">Rune</span>: <select name="attr_Weapon-Rune" class="PrimaryDropdown">
+                        <option value="">None</option>
+                        <option value="Wind Sword">Wind Sword</option>
+                        <option value="Shadow">Shadow</option>
+                        <option value="Slayer (Herbivore)">Slayer (Herbivore)</option>
+                        <option value="Slayer (Lance)">Slayer (Lance)</option>
+                        <option value="Evasive">Evasive</option>
+                        <option value="Mighty">Mighty</option>
+                        <option value="Resistant">Resistant</option>
+                        <option value="Slayer (Fly)">Slayer (Fly)</option>
+                        <option value="Heavy">Heavy</option>
+                        <option value="Slayer (Nobility)">Slayer (Nobility)</option>
+                        <option value="Wicked">Wicked</option>
+                        <option value="Slayer (Bow)">Slayer (Bow)</option>
+                        <option value="Slayer (Staff)">Slayer (Staff)</option>
+                        <option value="Slayer (Wind)">Slayer (Wind)</option>
+                        <option value="Slayer (Goblin)">Slayer (Goblin)</option>
+                        <option value="Slayer (Beast)">Slayer (Beast)</option>
+                        <option value="Throwing">Throwing</option>
+                        <option value="Sweep">Sweep</option>
+                        <option value="Slayer (Ride)">Slayer (Ride)</option>
+                        <option value="Conquerer">Conquerer</option>
+                        <option value="Light">Light</option>
+                        <option value="Seeking">Seeking</option>
+                        <option value="Slayer (Knives)">Slayer (Knives)</option>
+                        <option value="Slayer (Gauntlet)">Slayer (Gauntlet)</option>
+                        <option value="Slayer (Sing)">Slayer (Sing)</option>
+                        <option value="Slayer (Light)">Slayer (Light)</option>
+                        <option value="Slayer (Elf)">Slayer (Elf)</option>
+                        <option value="Fortress">Fortress</option>
+                        <option value="Slayer (Dragon)">Slayer (Dragon)</option>
+                        <option value="Slayer (Human)">Slayer (Human)</option>
+                        <option value="Fire Lance">Fire Lance</option>
+                        <option value="Slayer (Axe)">Slayer (Axe)</option>
+                        <option value="Slayer (Flintlock)">Slayer (Flintlock)</option>
+                        <option value="Healing">Healing</option>
+                        <option value="Slayer (Cyborg)">Slayer (Cyborg)</option>
+                        <option value="Slayer (Crossbow)">Slayer (Crossbow)</option>
+                        <option value="Slayer (Orc)">Slayer (Orc)</option>
+                        <option value="Blessed">Blessed</option>
+                        <option value="Bolt Axe">Bolt Axe</option>
+                        <option value="Slayer (Fire)">Slayer (Fire)</option>
+                        <option value="Slayer (Carnivore)">Slayer (Carnivore)</option>
+                        <option value="Slayer (Sword)">Slayer (Sword)</option>
+                        <option value="Slayer (Runed)">Slayer (Runed)</option>
+                        <option value="Slayer (Dwarf)">Slayer (Dwarf)</option>
+                        <option value="Reaver">Reaver</option>
+                        <option value="Defensive">Defensive</option>
+                        <option value="Slayer (Armored)">Slayer (Armored)</option>
+                        <option value="Brave">Brave</option>
+                        <option value="Hero">Hero</option>
+                        <option value="Masterwork">Masterwork</option>
+                    </select></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Damage-Type-Label">Damage Type</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-DamageType" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Color-Label">Color</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Color" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Tier-Label">Tier</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Tier" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-Might" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-Accuracy" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-Critical" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Range-Min-Label">Range Min</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-RangeMin" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Range-Max-Label">Range Max</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-RangeMax" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="STR-Full-Name">Strength</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-STR" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="INT-Full-Name">Intelligence</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-INT" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="DEX-Full-Name">Dexterity</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-DEX" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="SPD-Full-Name">Speed</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-SPD" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="LUK-Full-Name">Luck</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-LUK" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="CON-Full-Name">Constitution</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-CON" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="WIS-Full-Name">Wisdom</span>: <input type="number" class="PrimaryEntry" name="attr_Weapon-WIS" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Special-Label">Special</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Special" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Slayer-Label">Slayer</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Slayer" readonly/></label>
+                    <label class="PrimaryLabel"><span data-i18n="Weapon-Description-Label">Notes</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Notes" readonly/></label>
                 </fieldset>
               </div>
             </div>
@@ -388,19 +486,41 @@
               <div class="CharacterSheetFlexObject">
                 <fieldset class="repeating_items">
                   <h2 data-i18n="Item-Title">Item</h2>
-                  <label class="PrimaryLabel"><span data-i18n="Item-Name-Label">Name</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Name"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="Item-Description-Label">Description</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Description"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="Item-Tier-Label">Tier</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Tier"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="HP-Abbrev-Name">HP</span>: <input type="text" class="PrimaryEntry" name="attr_Item-HP"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Might"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Accuracy"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Critical"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Dodge"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Avoid"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Defense"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Resistance"/></label>
-                  <label class="PrimaryLabel"><span data-i18n="MOV-Full-Name">Movement</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Move"/></label>
-                  <!-- ToDo: Finish Item Section -->
+                  <label class="PrimaryLabel"><span data-i18n="Item-Selector-Label">Template</span>: <select name="attr_Item-Template" class="PrimaryDropdown">
+                    <option value="Cursed Ring (Legend)">Cursed Ring (Legend)</option>
+                    <option value="Angel Ring (Legend)">Angel Ring (Legend)</option>
+                    <option value="Hermes Shoes">Hermes Shoes</option>
+                    <option value="Setiemson">Setiemson</option>
+                    <option value="Tynar Rouge">Tynar Rouge</option>
+                    <option value="Cursed Ring (Epic)">Cursed Ring (Epic)</option>
+                    <option value="Diamond Bracelet">Diamond Bracelet</option>
+                    <option value="Elven Cloak">Elven Cloak</option>
+                    <option value="Jade Armlet">Jade Armlet</option>
+                    <option value="Cursed Ring (Hero)">Cursed Ring (Hero)</option>
+                    <option value="Cherche">Cherche</option>
+                    <option value="Germinas Boots">Germinas Boots</option>
+                    <option value="Glove">Glove</option>
+                    <option value="Angel Ring (Hero)">Angel Ring (Hero)</option>
+                    <option value="Empyreal Armband">Empyreal Armband</option>
+                    <option value="Angel Ring (Epic)">Angel Ring (Epic)</option>
+                    <option value="Shoulder Cape">Shoulder Cape</option>
+                    <option value="Feather Mantle">Feather Mantle</option>
+                    <option value="Battle Boots">Battle Boots</option>
+                    <option value="Gauntlet">Gauntlet</option>
+                    <option value="Bracer">Bracer</option>
+                  </select></label>
+                  <label class="PrimaryLabel"><span data-i18n="Item-Name-Label">Name</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Name" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="Item-Description-Label">Description</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Description" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="Item-Tier-Label">Tier</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Tier" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="HP-Abbrev-Name">HP</span>: <input type="number" class="PrimaryEntry" name="attr_Item-HP" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Might" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Accuracy" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Critical" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Dodge" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Avoid" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Defense" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Resistance" readonly/></label>
+                  <label class="PrimaryLabel"><span data-i18n="MOV-Full-Name">Movement</span>: <input type="number" class="PrimaryEntry" name="attr_Item-Move" readonly/></label>
                 </fieldset>
               </div>
             </div>
@@ -1272,6 +1392,192 @@
     });
   };
 
+
+
+  function toNumber(value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  function parseWorkerFormula(value, level = 1) {
+    if (value === undefined || value === null || value === "") { return 0; }
+    if (typeof value === "number") { return value; }
+    const cleaned = String(value).trim();
+    if (cleaned.endsWith("lvl")) {
+      return toNumber(cleaned.replace("lvl", "")) * toNumber(level);
+    }
+    return toNumber(cleaned);
+  }
+
+  function buildRangeLabel(minRange, maxRange) {
+    const min = toNumber(minRange);
+    const max = toNumber(maxRange);
+    return (min === max) ? `${min}` : `${min}-${max}`;
+  }
+
+  function getRuneData(runeName) {
+    if (!runeName || !RuneStats[runeName]) {
+      return {
+        Name: "",
+        Description: "",
+        Level: 0,
+        Type: "",
+        Might: 0,
+        Accuracy: 0,
+        Critical: 0,
+        RangeMin: 0,
+        RangeMax: 0
+      };
+    }
+    const rune = RuneStats[runeName];
+    const level = toNumber(rune.Level);
+    return {
+      Name: rune.Name || "",
+      Description: rune.Description || "",
+      Level: level,
+      Type: rune.Type || "",
+      Might: parseWorkerFormula(rune.Might, level),
+      Accuracy: parseWorkerFormula(rune.Accuracy, level),
+      Critical: parseWorkerFormula(rune.Critical, level),
+      RangeMin: parseWorkerFormula(rune.RangeMin, level),
+      RangeMax: parseWorkerFormula(rune.RangeMax, level)
+    };
+  }
+
+  function CalculateFrontSheetStats() {
+    getAttrs([
+      "str_stat_total","int_stat_total","dex_stat_total","spd_stat_total","luk_stat_total","con_stat_total","wis_stat_total",
+      "Equipped_Weapon_DamageType","Equipped_Weapon_Might","Equipped_Weapon_Accuracy","Equipped_Weapon_Critical",
+      "Equipped_Weapon_STR","Equipped_Weapon_INT","Equipped_Weapon_DEX","Equipped_Weapon_SPD","Equipped_Weapon_LUK","Equipped_Weapon_CON","Equipped_Weapon_WIS",
+      "Equipped_Item_Might","Equipped_Item_Accuracy","Equipped_Item_Critical","Equipped_Item_Dodge","Equipped_Item_Avoid","Equipped_Item_Defense","Equipped_Item_Resistance"
+    ], function(v) {
+      const effectiveStr = toNumber(v.str_stat_total) + toNumber(v.Equipped_Weapon_STR);
+      const effectiveInt = toNumber(v.int_stat_total) + toNumber(v.Equipped_Weapon_INT);
+      const effectiveDex = toNumber(v.dex_stat_total) + toNumber(v.Equipped_Weapon_DEX);
+      const effectiveSpd = toNumber(v.spd_stat_total) + toNumber(v.Equipped_Weapon_SPD);
+      const effectiveLuk = toNumber(v.luk_stat_total) + toNumber(v.Equipped_Weapon_LUK);
+      const effectiveCon = toNumber(v.con_stat_total) + toNumber(v.Equipped_Weapon_CON);
+      const effectiveWis = toNumber(v.wis_stat_total) + toNumber(v.Equipped_Weapon_WIS);
+
+      const isMagicWeapon = String(v.Equipped_Weapon_DamageType || "").toLowerCase() === "magical";
+      const powerStat = isMagicWeapon ? effectiveInt : effectiveStr;
+
+      const weaponMight = toNumber(v.Equipped_Weapon_Might);
+      const weaponAccuracy = toNumber(v.Equipped_Weapon_Accuracy);
+      const weaponCritical = toNumber(v.Equipped_Weapon_Critical);
+
+      const itemMight = toNumber(v.Equipped_Item_Might);
+      const itemAccuracy = toNumber(v.Equipped_Item_Accuracy);
+      const itemCritical = toNumber(v.Equipped_Item_Critical);
+      const itemDodge = toNumber(v.Equipped_Item_Dodge);
+      const itemAvoid = toNumber(v.Equipped_Item_Avoid);
+      const itemDefense = toNumber(v.Equipped_Item_Defense);
+      const itemResistance = toNumber(v.Equipped_Item_Resistance);
+
+      const attackMight = powerStat + weaponMight + itemMight;
+      const attackAccuracy = (effectiveDex * 2) + effectiveLuk + weaponAccuracy + itemAccuracy;
+      const attackCritical = effectiveDex + Math.floor(effectiveLuk / 2) + weaponCritical + itemCritical;
+      const attackDodge = (effectiveSpd * 2) + itemDodge;
+      const attackAvoid = (effectiveSpd * 2) + effectiveLuk + itemAvoid;
+      const attackDefense = effectiveCon + itemDefense;
+      const attackResistance = effectiveWis + itemResistance;
+
+      setAttrs({
+        AttackMight: attackMight,
+        AttackAccuracy: attackAccuracy,
+        AttackCritical: attackCritical,
+        AttackDodge: attackDodge,
+        AttackAvoid: attackAvoid,
+        AttackDefense: attackDefense,
+        AttackResistance: attackResistance,
+        RiposteMight: attackMight,
+        RiposteAccuracy: attackAccuracy,
+        RiposteCritical: attackCritical,
+        RiposteDodge: attackDodge,
+        RiposteAvoid: attackAvoid,
+        RiposteDefense: attackDefense,
+        RiposteResistance: attackResistance
+      });
+    });
+  }
+
+  function EquipWeaponFromRow(rowId) {
+    const weaponName = `repeating_weapons_${rowId}_Weapon-Name`;
+    const weaponType = `repeating_weapons_${rowId}_Weapon-Type`;
+    const weaponRune = `repeating_weapons_${rowId}_Weapon-Rune`;
+    getAttrs([weaponName, weaponType, weaponRune], function(values) {
+      const selectedWeaponName = values[weaponName] || values[weaponType] || "";
+      const selectedWeaponType = values[weaponType] || selectedWeaponName;
+      const selectedRune = values[weaponRune] || "";
+
+      const baseWeapon = WeaponStats[selectedWeaponType] || WeaponStats[selectedWeaponName];
+      if (!baseWeapon) { return; }
+
+      const rune = getRuneData(selectedRune);
+      const finalMight = toNumber(baseWeapon.Might) + rune.Might;
+      const finalAccuracy = toNumber(baseWeapon.Accuracy) + rune.Accuracy;
+      const finalCritical = toNumber(baseWeapon.Critical) + rune.Critical;
+      const rangeMin = toNumber(baseWeapon.RangeMin) + rune.RangeMin;
+      const rangeMax = toNumber(baseWeapon.RangeMax) + rune.RangeMax;
+      const notes = [baseWeapon.Special, rune.Description].filter(Boolean).join(" | ");
+
+      setAttrs({
+        Equipped_Weapon_Name: values[weaponName] || baseWeapon.Name || selectedWeaponType,
+        Equipped_Weapon_Rune: rune.Name,
+        Equipped_Weapon_Color: baseWeapon.Color || "",
+        Equipped_Weapon_Might: finalMight,
+        Equipped_Weapon_Accuracy: finalAccuracy,
+        Equipped_Weapon_Critical: finalCritical,
+        Equipped_Weapon_Range_Min: rangeMin,
+        Equipped_Weapon_Range_Max: rangeMax,
+        Equipped_Weapon_Range: buildRangeLabel(rangeMin, rangeMax),
+        Equipped_Weapon_DamageType: rune.Type || baseWeapon.DamageType || "Physical",
+        Equipped_Weapon_STR: toNumber(baseWeapon.str) + parseWorkerFormula(rune.str, rune.Level),
+        Equipped_Weapon_INT: toNumber(baseWeapon.int) + parseWorkerFormula(rune.int, rune.Level),
+        Equipped_Weapon_DEX: toNumber(baseWeapon.dex) + parseWorkerFormula(rune.dex, rune.Level),
+        Equipped_Weapon_SPD: toNumber(baseWeapon.spd) + parseWorkerFormula(rune.spd, rune.Level),
+        Equipped_Weapon_LUK: toNumber(baseWeapon.luk) + parseWorkerFormula(rune.luk, rune.Level),
+        Equipped_Weapon_CON: toNumber(baseWeapon.con) + parseWorkerFormula(rune.con, rune.Level),
+        Equipped_Weapon_WIS: toNumber(baseWeapon.wis) + parseWorkerFormula(rune.wis, rune.Level),
+        Equipped_Weapon_Notes: notes,
+        Equipped_Weapon_Type: baseWeapon.Type || ""
+      });
+
+      CalculateFrontSheetStats();
+    });
+  }
+
+  function EquipItemFromRow(rowId) {
+    const itemName = `repeating_items_${rowId}_Item-Name`;
+    const itemDescription = `repeating_items_${rowId}_Item-Description`;
+    const itemHP = `repeating_items_${rowId}_Item-HP`;
+    const itemMight = `repeating_items_${rowId}_Item-Might`;
+    const itemAccuracy = `repeating_items_${rowId}_Item-Accuracy`;
+    const itemCritical = `repeating_items_${rowId}_Item-Critical`;
+    const itemDodge = `repeating_items_${rowId}_Item-Dodge`;
+    const itemAvoid = `repeating_items_${rowId}_Item-Avoid`;
+    const itemDefense = `repeating_items_${rowId}_Item-Defense`;
+    const itemResistance = `repeating_items_${rowId}_Item-Resistance`;
+    const itemMove = `repeating_items_${rowId}_Item-Move`;
+
+    getAttrs([itemName,itemDescription,itemHP,itemMight,itemAccuracy,itemCritical,itemDodge,itemAvoid,itemDefense,itemResistance,itemMove], function(values) {
+      setAttrs({
+        Equipped_Item_Name: values[itemName] || "",
+        Equipped_Item_Notes: values[itemDescription] || "",
+        Equipped_Item_HP: toNumber(values[itemHP]),
+        Equipped_Item_Might: toNumber(values[itemMight]),
+        Equipped_Item_Accuracy: toNumber(values[itemAccuracy]),
+        Equipped_Item_Critical: toNumber(values[itemCritical]),
+        Equipped_Item_Dodge: toNumber(values[itemDodge]),
+        Equipped_Item_Avoid: toNumber(values[itemAvoid]),
+        Equipped_Item_Defense: toNumber(values[itemDefense]),
+        Equipped_Item_Resistance: toNumber(values[itemResistance]),
+        Equipped_Item_Move: toNumber(values[itemMove])
+      });
+      CalculateFrontSheetStats();
+    });
+  }
+
 /* Watch Events */
   on("change:background", function() {
     getAttrs(["background"], function(values) {
@@ -1362,6 +1668,107 @@
         });
     });
     CalculateSkillStats();
+  });
+
+
+
+  function PopulateWeaponRow(rowId) {
+    const weaponType = `repeating_weapons_${rowId}_Weapon-Type`;
+    const weaponRune = `repeating_weapons_${rowId}_Weapon-Rune`;
+    const weaponName = `repeating_weapons_${rowId}_Weapon-Name`;
+    getAttrs([weaponType, weaponRune, weaponName], function(values) {
+      const selectedWeaponType = values[weaponType] || "Copper Sword";
+      const selectedRune = values[weaponRune] || "";
+      const baseWeapon = WeaponStats[selectedWeaponType];
+      if (!baseWeapon) { return; }
+      const rune = getRuneData(selectedRune);
+      const rangeMin = toNumber(baseWeapon.RangeMin) + rune.RangeMin;
+      const rangeMax = toNumber(baseWeapon.RangeMax) + rune.RangeMax;
+      const notes = [baseWeapon.Special, rune.Description].filter(Boolean).join(" | ");
+
+      setAttrs({
+        [weaponName]: baseWeapon.Name || selectedWeaponType,
+        [`repeating_weapons_${rowId}_Weapon-DamageType`]: rune.Type || baseWeapon.DamageType || "Physical",
+        [`repeating_weapons_${rowId}_Weapon-Color`]: baseWeapon.Color || "",
+        [`repeating_weapons_${rowId}_Weapon-Tier`]: baseWeapon.Tier || "",
+        [`repeating_weapons_${rowId}_Weapon-Might`]: toNumber(baseWeapon.Might) + rune.Might,
+        [`repeating_weapons_${rowId}_Weapon-Accuracy`]: toNumber(baseWeapon.Accuracy) + rune.Accuracy,
+        [`repeating_weapons_${rowId}_Weapon-Critical`]: toNumber(baseWeapon.Critical) + rune.Critical,
+        [`repeating_weapons_${rowId}_Weapon-RangeMin`]: rangeMin,
+        [`repeating_weapons_${rowId}_Weapon-RangeMax`]: rangeMax,
+        [`repeating_weapons_${rowId}_Weapon-STR`]: toNumber(baseWeapon.str) + parseWorkerFormula(rune.str, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-INT`]: toNumber(baseWeapon.int) + parseWorkerFormula(rune.int, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-DEX`]: toNumber(baseWeapon.dex) + parseWorkerFormula(rune.dex, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-SPD`]: toNumber(baseWeapon.spd) + parseWorkerFormula(rune.spd, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-LUK`]: toNumber(baseWeapon.luk) + parseWorkerFormula(rune.luk, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-CON`]: toNumber(baseWeapon.con) + parseWorkerFormula(rune.con, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-WIS`]: toNumber(baseWeapon.wis) + parseWorkerFormula(rune.wis, rune.Level),
+        [`repeating_weapons_${rowId}_Weapon-Special`]: baseWeapon.Special || "",
+        [`repeating_weapons_${rowId}_Weapon-Slayer`]: baseWeapon.Slayer || "",
+        [`repeating_weapons_${rowId}_Weapon-Notes`]: notes
+      });
+    });
+  }
+
+  function PopulateItemRow(rowId) {
+    const itemTemplate = `repeating_items_${rowId}_Item-Template`;
+    getAttrs([itemTemplate], function(values) {
+      const selectedItem = values[itemTemplate];
+      const baseItem = ItemStats[selectedItem];
+      if (!baseItem) { return; }
+      setAttrs({
+        [`repeating_items_${rowId}_Item-Name`]: baseItem.Name || selectedItem,
+        [`repeating_items_${rowId}_Item-Description`]: baseItem.Description || "",
+        [`repeating_items_${rowId}_Item-Tier`]: baseItem.Tier || "",
+        [`repeating_items_${rowId}_Item-HP`]: toNumber(baseItem.HP),
+        [`repeating_items_${rowId}_Item-Might`]: toNumber(baseItem.Might),
+        [`repeating_items_${rowId}_Item-Accuracy`]: toNumber(baseItem.Accuracy),
+        [`repeating_items_${rowId}_Item-Critical`]: toNumber(baseItem.Critical),
+        [`repeating_items_${rowId}_Item-Dodge`]: toNumber(baseItem.Dodge),
+        [`repeating_items_${rowId}_Item-Avoid`]: toNumber(baseItem.Avoid),
+        [`repeating_items_${rowId}_Item-Defense`]: toNumber(baseItem.Defense),
+        [`repeating_items_${rowId}_Item-Resistance`]: toNumber(baseItem.Resistance),
+        [`repeating_items_${rowId}_Item-Move`]: toNumber(baseItem.Move)
+      });
+    });
+  }
+
+  function SyncEquipmentRowsFromSelectors() {
+    getSectionIDs("repeating_weapons", function(weaponIds) {
+      weaponIds.forEach(PopulateWeaponRow);
+    });
+    getSectionIDs("repeating_items", function(itemIds) {
+      itemIds.forEach(PopulateItemRow);
+    });
+  }
+
+  on("clicked:repeating_weapons:SetWeapon", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute) { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (rowId) { EquipWeaponFromRow(rowId); }
+  });
+
+  on("clicked:repeating_items:SetItem", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute) { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (rowId) { EquipItemFromRow(rowId); }
+  });
+
+  on("change:repeating_weapons:Weapon-Type change:repeating_weapons:Weapon-Rune", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute) { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (rowId) { PopulateWeaponRow(rowId); }
+  });
+
+  on("change:repeating_items:Item-Template", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute) { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (rowId) { PopulateItemRow(rowId); }
+  });
+
+  on("change:str_stat_total change:int_stat_total change:dex_stat_total change:spd_stat_total change:luk_stat_total change:con_stat_total change:wis_stat_total change:Equipped_Weapon_DamageType change:Equipped_Weapon_Might change:Equipped_Weapon_Accuracy change:Equipped_Weapon_Critical change:Equipped_Weapon_STR change:Equipped_Weapon_INT change:Equipped_Weapon_DEX change:Equipped_Weapon_SPD change:Equipped_Weapon_LUK change:Equipped_Weapon_CON change:Equipped_Weapon_WIS change:Equipped_Item_Might change:Equipped_Item_Accuracy change:Equipped_Item_Critical change:Equipped_Item_Dodge change:Equipped_Item_Avoid change:Equipped_Item_Defense change:Equipped_Item_Resistance sheet:opened", function() {
+    CalculateFrontSheetStats();
+    SyncEquipmentRowsFromSelectors();
   });
 
   StatList.forEach(stat => {


### PR DESCRIPTION
### Motivation
- Weapons need to carry base stat adjustments (STR/INT/DEX/SPD/LUK/CON/WIS) so weapon templates like katanas (SPD bonus with CON/WIS penalty) are represented in both the UI and combat math.
- The sheet should auto-populate those base stat modifiers from the on-disk `WeaponStats` plus rune scaling and apply them when computing front-sheet Attack/Riposte stats.

### Description
- Added read-only weapon base-stat fields (`attr_Weapon-STR/INT/DEX/SPD/LUK/CON/WIS`) to the Weapon Creation repeating row UI and corresponding hidden equipped attributes (`attr_Equipped_Weapon_STR/INT/DEX/SPD/LUK/CON/WIS`) to persist equipped modifiers.
- Updated `PopulateWeaponRow` to fill the new repeating-row stat fields from `WeaponStats` and to apply rune scaling via `parseWorkerFormula` when appropriate.
- Updated `EquipWeaponFromRow` to copy computed base stat modifiers (weapon + rune) into the equipped attributes so they are available to downstream logic.
- Reworked front-sheet calculation via `CalculateFrontSheetStats` to compute effective stats as `class totals + Equipped_Weapon_*` and to use those effective stats in Attack and Riposte formulas.
- Added small utility helpers `toNumber`, `parseWorkerFormula`, `buildRangeLabel`, and `getRuneData`, and wired the existing selector listeners and `SyncEquipmentRowsFromSelectors()` so rows and equipped state stay in sync.

### Testing
- Extracted the sheetworker script and ran `node --check /tmp/cs_worker.js` to validate JavaScript syntax, which completed successfully.
- Launched a local server with `python -m http.server 4173` and captured a Playwright screenshot of `http://127.0.0.1:4173/Roll20/CharacterSheet/CharacterSheetV3.html`, which completed successfully and shows the new weapon base-stat fields in the UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699391122dc4832d833d013ea86a05e4)