### PR TITLE
Polish CharacterSheetV3: full-width name header, restore repeating controls, remove colons, and themed roll template

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -51,6 +51,7 @@
 }
 
 .CharacterNameFlexItem {
+  width: 100%;
   max-width: 271px;
   justify-content: center;
 }
@@ -231,24 +232,40 @@
 /*Class*/
 .ClassStatGrid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1.2fr repeat(5, minmax(88px, 1fr));
   grid-template-rows: auto;
   grid-auto-flow: row;
+  gap: 4px;
   outline: none;
-  outline-width: 0;
-  outline-style: none;
   max-height: fit-content;
 }
 
 .ClassStatGridItem {
   grid-row: span 1;
   grid-column: span 1;
-  outline: auto;
-  outline-width: thin;
-  outline-style: solid;
-  padding: 5px;
+  padding: 4px 6px;
+  min-height: 34px;
   max-height: fit-content;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.ClassStatGridItem:nth-child(6n + 1) {
+  justify-content: flex-start;
+  font-weight: 700;
+}
+
+.ClassStatGridItem input {
+  width: 64px;
+  text-align: center;
+}
+
+.ClassStatGridItem .PrimaryLabel {
+  margin: 0;
+  width: 100%;
 }
 
 .charsheet .sheet-classskillslist-Check {
@@ -390,84 +407,115 @@ label.GreatSkillLegendary { display: none; }
 .charsheet .GreatSkillSelector[value="79"] ~ label.GreatSkillLegendary,
 .charsheet .GreatSkillSelector[value="80"] ~ label.GreatSkillLegendary { display: block; }
 
+
+
+.sheet-classskillslist-Short > .repcontainer[data-groupname="repeating_classskillslist"],
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"],
+.sheet-combatskillslist-Short > .repcontainer[data-groupname="repeating_combatskillslist"],
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.sheet-classskillslist-Short > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem,
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem,
+.sheet-combatskillslist-Short > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem,
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem {
+  border: 2px solid var(--fe-gold);
+  border-radius: 6px;
+  padding: 8px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+}
+
+.sheet-classskillslist-Short > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem label.PrimaryLabel,
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem label.PrimaryLabel,
+.sheet-combatskillslist-Short > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem label.PrimaryLabel,
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem label.PrimaryLabel {
+  display: grid;
+  grid-template-columns: 115px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 8px;
+  margin-bottom: 6px;
+}
+
+
+.sheet-classskillslist-Short > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem label.PrimaryLabel > span::after,
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem label.PrimaryLabel > span::after,
+.sheet-combatskillslist-Short > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem label.PrimaryLabel > span::after,
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem label.PrimaryLabel > span::after {
+  content: "";
+}
+
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem textarea.PrimaryDescription,
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem textarea.PrimaryDescription {
+  width: 100%;
+  max-width: 100%;
+  min-width: 100%;
+  min-height: 110px;
+}
+
+.sheet-classskillslist-Long > .repcontainer[data-groupname="repeating_classskillslist"] > .repitem label.PrimaryLabel:nth-last-child(-n+2),
+.sheet-combatskillslist-Long > .repcontainer[data-groupname="repeating_combatskillslist"] > .repitem label.PrimaryLabel:nth-last-child(-n+2) {
+  display: block;
+}
+
+.repcontrol[data-groupname=repeating_classskillslist],
+.repcontrol[data-groupname=repeating_combatskillslist] {
+  display: block;
+  visibility: visible;
+  margin-top: 8px;
+}
+
+.repcontrol[data-groupname=repeating_classskillslist] .btn,
+.repcontrol[data-groupname=repeating_combatskillslist] .btn {
+  border: 1px solid #b8b8b8;
+  border-radius: 4px;
+  background: #d7d7d7;
+  color: #3f3f3f;
+  font-weight: 600;
+  padding: 4px 10px;
+  margin-right: 6px;
+}
+
 /*Growth*/
 .GrowthGrid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1.2fr repeat(4, minmax(88px, 1fr));
   grid-template-rows: auto;
   grid-auto-flow: row;
+  gap: 4px;
   outline: none;
-  outline-width: 0;
-  outline-style: none;
   max-height: fit-content;
 }
 
 .GrowthGridItem {
   grid-row: span 1;
   grid-column: span 1;
-  outline: auto;
-  outline-width: thin;
-  outline-style: solid;
-  padding: 5px;
+  padding: 4px 6px;
+  min-height: 34px;
   max-height: fit-content;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.GrowthGridItem:nth-child(5n + 1) {
+  justify-content: flex-start;
+  font-weight: 700;
+}
+
+.GrowthGridItem input {
+  width: 64px;
   text-align: center;
 }
 
-.repcontainer[data-groupname=repeating_combatskillslist] {
-  display: table;
-  outline: none;
-  outline-width: 0;
-  outline-style: none;
-  max-height: fit-content;
-}
-
-.RepeatingcombatskillslistSection {
-  display: table-row;
-  outline: none;
-  outline-width: 0;
-  outline-style: none;
-  max-height: fit-content;
-}
-
-.RepeatingcombatskillslistSectionHeader {
-  display: none;
-  outline: none;
-  outline-width: 0;
-  outline-style: none;
-  max-height: fit-content;
-}
-
-.LevelupcombatskillslistGridItemHeader {
-  display: none;
-  outline: auto;
-  outline-width: thin;
-  outline-style: solid;
-  padding: 5px;
-  max-height: fit-content;
-  text-align: center;
-}
-
-.LevelupcombatskillslistGridItem {
-  display: table-cell;
-  outline: auto;
-  outline-width: thin;
-  outline-style: solid;
-  padding: 5px;
-  max-height: fit-content;
-  text-align: center;
-}
-
-.repcontainer[data-groupname=repeating_combatskillslist] > .repitem:first-child > .RepeatingcombatskillslistSectionHeader {
-  display: table-row;
-}
-
-.repcontainer[data-groupname=repeating_combatskillslist] > .repitem:first-child > .RepeatingcombatskillslistSectionHeader > .LevelupcombatskillslistGridItemHeader {
-  display: table-cell;
-}
-
-.repcontrol[data-groupname=repeating_combatskillslist]  {
-  display: none;
-  visibility: hidden;
+.GrowthGridItem .PrimaryLabel {
+  margin: 0;
+  width: 100%;
 }
 
 .repcontainer[data-groupname=repeating_CharacterLevel] {
@@ -533,62 +581,217 @@ label.GreatSkillLegendary { display: none; }
 /*Configuration*/
 
 /*Titles, Labels, and Input*/
+.charsheet {
+  --fe-red-dark: #66271f;
+  --fe-red-mid: #8a3a2e;
+  --fe-parchment: #efe7c7;
+  --fe-panel: #273a73;
+  --fe-panel-mid: #3f59a4;
+  --fe-panel-light: #5e76bf;
+  --fe-gold: #c8a05a;
+  --fe-gold-light: #e7cf8f;
+  --fe-ink: #1b1a21;
+  --fe-line: #1a2245;
+
+  color: var(--fe-ink);
+  font-family: "Trebuchet MS", "Verdana", sans-serif;
+}
+
+.charsheet .MasterGrid {
+  background: linear-gradient(155deg, #6f2b23 0%, var(--fe-red-mid) 38%, #4c1a17 100%);
+  border: 2px solid var(--fe-gold);
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 2px rgba(45, 16, 12, 0.45), 0 8px 22px rgba(15, 11, 20, 0.3);
+  padding: 8px;
+  column-gap: 8px;
+  row-gap: 8px;
+}
+
+.CharacterGridcell,
+.PageSelectorGridcell,
+.CharacterSheetGridcell,
+.CharacterEquippedFlexItem,
+.CharacterSheetFlexObject,
+.ClassStatGridItem,
+.GrowthGridItem,
+.LevelupcombatskillslistGridItem,
+.LevelupcombatskillslistGridItemHeader,
+.LevelupCharacterLevelGridItem,
+.LevelupCharacterLevelGridItemHeader,
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_weapons"],
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_weapons"] > .repitem,
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_weapons"],
+.SheetPageItem > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_items"],
+.SheetPageItem > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_items"] > .repitem,
+.SheetPageItem > .CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_items"] {
+  border: 2px solid var(--fe-gold);
+  border-radius: 6px;
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(233, 221, 186, 0.32);
+}
+
+.CharacterGridcell,
+.PageSelectorGridcell {
+  background: linear-gradient(145deg, #f8f2dc 0%, var(--fe-parchment) 100%);
+  color: var(--fe-ink);
+}
+
+.CharacterSheetGridcell {
+  background: linear-gradient(145deg, #445ca4 0%, #354c8e 100%);
+}
+
+.CharacterEquippedFlexItem,
+.CharacterSheetFlexObject,
+.ClassStatGridItem,
+.GrowthGridItem,
+.LevelupcombatskillslistGridItem,
+.LevelupcombatskillslistGridItemHeader,
+.LevelupCharacterLevelGridItem,
+.LevelupCharacterLevelGridItemHeader,
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_weapons"],
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_weapons"] > .repitem,
+.SheetPageWeapon > .CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_weapons"],
+.SheetPageItem > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_items"],
+.SheetPageItem > .CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_items"] > .repitem,
+.SheetPageItem > .CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_items"] {
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  color: #2b2521;
+}
+
+.CharacterPicFlexItem img,
+.CharacterTokenFlexItem img {
+  width: 100%;
+  border: 2px solid var(--fe-gold);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(12, 10, 18, 0.35);
+}
+
 .PrimaryTitle {
-  font: auto;
+  margin: 0 0 8px;
+  padding-bottom: 3px;
+  border-bottom: 1px solid rgba(98, 51, 19, 0.35);
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #623313;
+}
+
+.CharacterNameHeader {
+  width: 100%;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #623313;
+  background: transparent;
+  border: 1px solid rgba(168, 140, 87, 0.75);
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.CharacterNameHeader:focus {
+  background: #fff9ea;
+}
+
+.BuilderNameHeader {
+  display: block;
+  width: calc(100% - 14px);
+  margin: 0 0 10px;
+  padding: 2px 6px 3px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: #623313;
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.15;
+}
+
+.BuilderNameHeader:focus {
+  border-color: #a88c57;
+  background: #fff9ea;
 }
 
 .PrimaryLabel {
-  font: auto;
+  display: block;
   width: fit-content;
+  margin-bottom: 2px;
+  font-size: 0.84rem;
+  letter-spacing: 0.02em;
 }
 
-.PrimaryEntry {
-  font: auto;
-  outline: none;
-  width: auto;
+.PrimaryEntry,
+.PrimaryDropdown,
+select,
+input[type="text"],
+input[type="number"] {
+  border: 1px solid #a88c57;
+  border-radius: 4px;
+  background: #fff9ea;
+  color: #1d2130;
+  padding: 2px 6px;
+  min-height: 24px;
+}
+
+.PrimaryEntry:focus,
+.PrimaryDropdown:focus,
+textarea:focus,
+select:focus,
+button:focus {
+  outline: 2px solid #89a7ff;
+  outline-offset: 1px;
+}
+
+.PrimaryNotesEntry,
+.PrimaryDescription,
+textarea {
+  border: 1px solid #9f8752;
+  border-radius: 4px;
+  width: 96%;
+  max-width: 96%;
+  min-width: 96%;
+  background: #fff9ea;
+  color: #1c2030;
+  resize: vertical;
 }
 
 .PrimaryNotesEntry {
-  outline: none;
-  width: 96%;
-  max-width: 96%;
-  min-width: 96%;
   height: 98%;
   max-height: 98%;
   min-height: 98%;
-  background: none;
-  resize: none;
 }
 
-.PrimaryDescription {
-  outline: none;
-  width: 96%;
-  max-width: 96%;
-  min-width: 96%;
-  height: auto;
-  background: none;
-  resize: auto;
+.PrimaryButton,
+button[type="roll"],
+button[type="action"] {
+  border: 1px solid #f2d79e;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #3f64bf 0%, #2d458a 100%);
+  color: #fffdf5;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  padding: 3px 8px;
+  min-height: 24px;
+  box-shadow: inset 0 0 0 1px rgba(244, 232, 203, 0.35);
 }
 
-.PrimaryDropdown {
-  font: auto;
-  width: fit-content;
-}
-
-.PrimaryButton {
-  font: auto;
-  height: fit-content;
-  width: fit-content;
+.PrimaryButton:hover,
+button[type="roll"]:hover,
+button[type="action"]:hover {
+  filter: brightness(1.08);
 }
 
 .OptionCategoryH1 {
-  background:gray;
-  font-weight:bold;
-  color:white;
+  background: #324a8d;
+  font-weight: bold;
+  color: #f5e9c5;
 }
 
 .OptionCategoryH2 {
-  font-weight:bold;
+  font-weight: bold;
+  color: #d7c18d;
 }
 
 /*Page Selector Logic*/
@@ -614,37 +817,64 @@ label.GreatSkillLegendary { display: none; }
 
 /* Roll template: adelphiaattack */
 .sheet-rolltemplate-adelphiaattack {
-  border: 1px solid #1f2937;
-  background: #f8fafc;
-  border-radius: 6px;
+  border: 2px solid #c8a05a;
+  background: linear-gradient(155deg, #6f2b23 0%, #8a3a2e 40%, #4c1a17 100%);
+  border-radius: 8px;
   padding: 8px;
-}
-
-.sheet-rolltemplate-adelphiaattack .sheet-template-container {
-  display: grid;
-  grid-template-columns: 1fr;
-  row-gap: 4px;
+  box-shadow: inset 0 0 0 1px rgba(233, 221, 186, 0.25);
+  color: #2b2521;
 }
 
 .sheet-rolltemplate-adelphiaattack .sheet-template-title {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  color: #623313;
+  padding: 4px 8px;
   font-weight: 700;
-  font-size: 1.05em;
-  margin-bottom: 4px;
+  font-size: 1.1em;
+  margin-bottom: 8px;
+}
+
+.sheet-rolltemplate-adelphiaattack .sheet-template-body {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #445ca4 0%, #354c8e 100%);
+  padding: 8px;
+  display: grid;
+  gap: 8px;
+}
+
+.sheet-rolltemplate-adelphiaattack .sheet-template-panel {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  padding: 6px;
 }
 
 .sheet-rolltemplate-adelphiaattack .sheet-template-section {
-  margin-top: 6px;
+  border-bottom: 1px solid rgba(98, 51, 19, 0.35);
+  margin-bottom: 6px;
+  padding-bottom: 2px;
   font-weight: 700;
-  border-bottom: 1px solid #94a3b8;
+  color: #623313;
+  text-transform: uppercase;
 }
 
 .sheet-rolltemplate-adelphiaattack .sheet-template-row {
   display: grid;
   grid-template-columns: 130px 1fr;
-  column-gap: 10px;
+  column-gap: 8px;
   align-items: start;
+  font-size: 0.95em;
+  margin-bottom: 2px;
 }
 
 .sheet-rolltemplate-adelphiaattack .sheet-template-row > span:first-child {
-  font-weight: 600;
+  font-weight: 700;
+  color: #623313;
+}
+
+.sheet-rolltemplate-adelphiaattack .sheet-template-row > span:last-child {
+  color: #1f2435;
 }

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -1,4 +1,4 @@
-<link href="CharactersheetV2.css" rel="stylesheet" type="text/css">
+<link href="CharacterSheetV3.css" rel="stylesheet" type="text/css">
 
 <div class="MasterGrid"> <!-- The Character Sheet Layout -->
 
@@ -6,7 +6,7 @@
 
         <div class="CharacterFlexContainer"> <!-- Character Picture and Info -->
             
-            <div class="CharacterNameFlexItem"><input type="text" class="PrimaryEntry" name="attr_character_name" placeholder="Name" data-i18n-place="name-u"/></div>
+            <div class="CharacterNameFlexItem"><input type="text" class="PrimaryEntry CharacterNameHeader" name="attr_character_name" placeholder="Name" data-i18n-place="name-u"/></div>
             <div class="CharacterPicFlexItem"><img name="attr_character_avatar"/></div>
             <div class="CharacterTokenFlexItem"><img name="attr_character_token"/></div>
             <div class="CharacterDescriptionFlexItem"><textarea name="attr_character_notes" class="PrimaryNotesEntry" placeholder="Character Notes" data-i18n-place="sheet-CharacterNotesPlaceholder" ></textarea></div>
@@ -176,8 +176,7 @@
               </div>
               <div class="CharacterSheetFlexObject">
                 <fieldset class="repeating_weapons">
-                    <h2 data-i18n="Weapon-Title">Weapon</h2>
-                    <label class="PrimaryLabel"><span data-i18n="Weapon-Name-Label">Name</span>: <input type="text" class="PrimaryEntry" name="attr_Weapon-Name"/></label>
+                    <input type="text" class="BuilderNameHeader" name="attr_Weapon-Name" placeholder="Weapon Name" data-i18n-place="Weapon-Name-Label"/>
                     <label class="PrimaryLabel"><span data-i18n="Weapon-Type-Label">Type</span>: <select name="attr_Weapon-Type">
                         <option disabled data-i18n="Weapon-Type-Physical" class="OptionCategoryH1">Physical</option>
                         <option disabled data-i18n="Weapon-Type-Sword-indent" class="OptionCategoryH2"> > Sword</option>
@@ -487,7 +486,7 @@
               </div>
               <div class="CharacterSheetFlexObject">
                 <fieldset class="repeating_items">
-                  <h2 data-i18n="Item-Title">Item</h2>
+                  <input type="text" class="BuilderNameHeader" name="attr_Item-Name" readonly/>
                   <label class="PrimaryLabel"><span data-i18n="Item-Selector-Label">Template</span>: <select name="attr_Item-Template" class="PrimaryDropdown">
                     <option value="Cursed Ring (Legend)">Cursed Ring (Legend)</option>
                     <option value="Angel Ring (Legend)">Angel Ring (Legend)</option>
@@ -511,7 +510,6 @@
                     <option value="Gauntlet">Gauntlet</option>
                     <option value="Bracer">Bracer</option>
                   </select></label>
-                  <label class="PrimaryLabel"><span data-i18n="Item-Name-Label">Name</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Name" readonly/></label>
                   <label class="PrimaryLabel"><span data-i18n="Item-Description-Label">Description</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Description" readonly/></label>
                   <label class="PrimaryLabel"><span data-i18n="Item-Tier-Label">Tier</span>: <input type="text" class="PrimaryEntry" name="attr_Item-Tier" readonly/></label>
                   <label class="PrimaryLabel"><span data-i18n="HP-Abbrev-Name">HP</span>: <input type="number" class="PrimaryEntry" name="attr_Item-HP" readonly/></label>
@@ -614,7 +612,7 @@
                     <input type="checkbox" class="sheet-classskillslist-Check" name="attr_classskillslist-Check" value="0" />
                     <div class="sheet-classskillslist-Short">
                         <fieldset class="repeating_classskillslist">
-                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Name">Skill</span>: <select name="attr_ClassSkill">
+                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Name">Skill</span> <select name="attr_ClassSkill">
                                 <option value="Nobility" data-i18n="Class-Skill-Nobility">Nobility</option>
                                 <option value="Ride" data-i18n="Class-Skill-Ride">Ride</option>
                                 <option value="Fly" data-i18n="Class-Skill-Fly">Fly</option>
@@ -629,7 +627,7 @@
                     </div>
                     <div class="sheet-classskillslist-Long">
                         <fieldset class="repeating_classskillslist">
-                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Name">Skill</span>: <select name="attr_ClassSkill">
+                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Name">Skill</span> <select name="attr_ClassSkill">
                                 <option value="Nobility" data-i18n="Class-Skill-Nobility">Nobility</option>
                                 <option value="Ride" data-i18n="Class-Skill-Ride">Ride</option>
                                 <option value="Fly" data-i18n="Class-Skill-Fly">Fly</option>
@@ -640,9 +638,9 @@
                                 <option value="Weapon Skill" data-i18n="Class-Skill-Weapon Skill">Weapon Skill</option>
                                 </select>
                             </label>
-                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Cost">Cost</span>: <input type="number" name="attr_ClassSkillCost" /></label>
-                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Description">Description</span>: <textarea class="PrimaryDescription" name="attr_ClassSkillDescription"></textarea></label>
-                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Effect">Effect</span>: <textarea class="PrimaryDescription" name="attr_ClassSkillEffect"></textarea></label>
+                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Cost">Cost</span> <input type="number" name="attr_ClassSkillCost" /></label>
+                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Description">Description</span> <textarea class="PrimaryDescription" name="attr_ClassSkillDescription"></textarea></label>
+                            <label class="PrimaryLabel"><span data-i18n="Class-Skill-Effect">Effect</span> <textarea class="PrimaryDescription" name="attr_ClassSkillEffect"></textarea></label>
                         </fieldset>
                     </div>
                 </div>
@@ -650,11 +648,11 @@
             <div class="SheetPageSkills"> <!-- Character Skills Creation-->
                 <div class="CharacterSheetFlexObject"> <!-- Combat Skills-->
                     <h1 class="PrimaryTitle" data-i18n="Levelup-Combat-Skills-title-u">Combat Skills</h1>
-                    <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Points-Available">Skill Points</span>: <span name="attr_CombatSkillPointsAvailable"></span></label>
+                    <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Points-Available">Skill Points</span> <span name="attr_CombatSkillPointsAvailable"></span></label>
                     <input type="checkbox" class="sheet-combatskillslist-Check" name="attr_combatskillslist-Check" value="0" />
                     <div class="sheet-combatskillslist-Short">
                         <fieldset class="repeating_combatskillslist">
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span>: <select name="attr_CombatSkill">
+                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
                                 <option value="Buckler" selected="selected" data-i18n="Combat-Skill-Buckler">Buckler</option>
@@ -693,7 +691,7 @@
                     </div>
                     <div class="sheet-combatskillslist-Long">
                         <fieldset class="repeating_combatskillslist">
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span>: <select name="attr_CombatSkill">
+                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
                                 <option value="Buckler" selected="selected" data-i18n="Combat-Skill-Buckler">Buckler</option>
@@ -730,7 +728,7 @@
                                 </select>
                             </label>
                             <input type="hidden" class="StatCombatSkillSelectorDisplay" name="attr_StatCombatSkillSelectorDisplay" value="0" />
-                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-stat">Stat</span>: <select name="attr_StatCombatSkillSelector">
+                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-stat">Stat</span> <select name="attr_StatCombatSkillSelector">
                                 <option value="STR" selected="selected" data-i18n="STR-Full-Name">Strength</option>
                                 <option value="INT" selected="selected" data-i18n="INT-Full-Name">Intelligence</option>
                                 <option value="DEX" selected="selected" data-i18n="DEX-Full-Name">Dexterity</option>
@@ -741,7 +739,7 @@
                                 </select>
                             </label>
                             <input type="hidden" class="WeaponCombatSkillSelectorDisplay" name="attr_WeaponCombatSkillSelectorDisplay" value="0"/>
-                            <label class="PrimaryLabel"><span data-i18n="Weapon-Title">Weapon</span>: <select name="attr_WeaponCombatSkillSelector">
+                            <label class="PrimaryLabel"><span data-i18n="Weapon-Title">Weapon</span> <select name="attr_WeaponCombatSkillSelector">
                                 <option disabled data-i18n="Weapon-Type-Physical" class="OptionCategoryH1">Physical</option>
                                 <option disabled data-i18n="Weapon-Type-Sword-indent" class="OptionCategoryH2"> > Sword</option>
                                 <option value="Copper Sword" selected="selected" data-i18n="Copper Sword-Full-Name">Copper Sword</option>
@@ -970,20 +968,20 @@
                                 <option value="Gilded Slam" selected="selected" data-i18n="Gilded Slam-Full-Name">Gilded Slam</option>
                                 <option value="Orichalcum Slam" selected="selected" data-i18n="Orichalcum Slam-Full-Name">Orichalcum Slam</option>
                             </select></label>
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Level">Level</span>: <input type="number" name="attr_CombatSkillLevel" min="1"/></label>
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Description">Description</span>: <textarea class="PrimaryDescription" name="attr_CombatSkillDescription"></textarea></label>
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Effect">Effect</span>: <textarea class="PrimaryDescription" name="attr_CombatSkillEffect"></textarea></label>
+                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Level">Level</span> <input type="number" name="attr_CombatSkillLevel" min="1"/></label>
+                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Description">Description</span> <textarea class="PrimaryDescription" name="attr_CombatSkillDescription"></textarea></label>
+                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Effect">Effect</span> <textarea class="PrimaryDescription" name="attr_CombatSkillEffect"></textarea></label>
                         </fieldset>
                     </div>
                 </div>
                 <div class="CharacterSheetFlexObject"> <!-- Great Skills-->
                     <h1 class="PrimaryTitle" data-i18n="Levelup-Great-Skills-title-u">Great Skills</h1>
                     <input type="hidden" class="GreatSkillSelector" name="attr_character_level">
-                    <label class="PrimaryLabel GreatSkillHeroic"><span data-i18n="Great-Skill-Name">Skill</span>: <select name="attr_GreatSkill">
+                    <label class="PrimaryLabel GreatSkillHeroic"><span data-i18n="Great-Skill-Name">Skill</span> <select name="attr_GreatSkill">
                         <option value="None" selected="selected" data-i18n="Great-Skill-None">None</option>
                         </select>
                     </label>
-                    <label class="PrimaryLabel GreatSkillEpic"><span data-i18n="Great-Skill-Name">Skill</span>: <select name="attr_GreatSkill">
+                    <label class="PrimaryLabel GreatSkillEpic"><span data-i18n="Great-Skill-Name">Skill</span> <select name="attr_GreatSkill">
                         <option value="Moon Strike" selected="selected" data-i18n="Great-Skill-Moon Strike">Moon Strike</option>
                         <option value="Sun Strike" selected="selected" data-i18n="Great-Skill-Sun Strike">Sun Strike</option>
                         <option value="Brave Strike" selected="selected" data-i18n="Great-Skill-Brave Strike">Brave Strike</option>
@@ -993,7 +991,7 @@
                         <option value="Waiting Block" selected="selected" data-i18n="Great-Skill-Waiting Block">Waiting Block</option>
                         </select>
                     </label>
-                    <label class="PrimaryLabel GreatSkillLegendary"><span data-i18n="Great-Skill-Name">Skill</span>: <select name="attr_GreatSkill">
+                    <label class="PrimaryLabel GreatSkillLegendary"><span data-i18n="Great-Skill-Name">Skill</span> <select name="attr_GreatSkill">
                         <option value="Lunar Impact" selected="selected" data-i18n="Great-Skill-Lunar Impact">Lunar Impact</option>
                         <option value="Lunar Strike" selected="selected" data-i18n="Great-Skill-Lunar Strike">Lunar Strike</option>
                         <option value="Solar Impact" selected="selected" data-i18n="Great-Skill-Solar Impact">Solar Impact</option>
@@ -1012,8 +1010,8 @@
                         <option value="Resistant Block" selected="selected" data-i18n="Great-Skill-Resistant Block">Resistant Block</option>
                         </select>
                     </label>
-                    <label class="PrimaryLabel"><span data-i18n="Great-Skill-Level">Level</span>: <span name="attr_GreatSkillLevel"></span></label>
-                    <label class="PrimaryLabel"><span data-i18n="Great-Skill-Description">Description</span>: <textarea class="PrimaryNotesEntry" name="attr_GreatSkillDescription"></textarea></label>
+                    <label class="PrimaryLabel"><span data-i18n="Great-Skill-Level">Level</span> <span name="attr_GreatSkillLevel"></span></label>
+                    <label class="PrimaryLabel"><span data-i18n="Great-Skill-Description">Description</span> <textarea class="PrimaryNotesEntry" name="attr_GreatSkillDescription"></textarea></label>
                 </div>
             </div>
             <div class="SheetPageGrowth"> <!-- Character Growth Potential-->
@@ -1179,22 +1177,28 @@
 <rolltemplate class="sheet-rolltemplate-adelphiaattack">
   <div class="sheet-template-container">
     {{#name}}<div class="sheet-template-title">{{name}}</div>{{/name}}
-    {{#shared_roll}}<div class="sheet-template-row"><span>Roll (d100)</span><span>{{shared_roll}}</span></div>{{/shared_roll}}
-    {{#attack_header}}<div class="sheet-template-section">{{attack_header}}</div>{{/attack_header}}
-    {{#attack_roll}}<div class="sheet-template-row"><span>Attack Roll</span><span>{{attack_roll}}</span></div>{{/attack_roll}}
-    {{#critical_roll}}<div class="sheet-template-row"><span>Critical Roll</span><span>{{critical_roll}}</span></div>{{/critical_roll}}
-    {{#damage}}<div class="sheet-template-row"><span>Damage</span><span>{{damage}}</span></div>{{/damage}}
-    {{#speed}}<div class="sheet-template-row"><span>Speed</span><span>{{speed}}</span></div>{{/speed}}
-    {{#weapon_range}}<div class="sheet-template-row"><span>Weapon Range</span><span>{{weapon_range}}</span></div>{{/weapon_range}}
-    {{#weapon_properties}}<div class="sheet-template-row"><span>Weapon Properties</span><span>{{weapon_properties}}</span></div>{{/weapon_properties}}
-    {{#item_properties}}<div class="sheet-template-row"><span>Item Properties</span><span>{{item_properties}}</span></div>{{/item_properties}}
-    {{#great_skill}}<div class="sheet-template-row"><span>Great Skill</span><span>{{great_skill}}</span></div>{{/great_skill}}
-    {{#defense_header}}<div class="sheet-template-section">{{defense_header}}</div>{{/defense_header}}
-    {{#defense_speed}}<div class="sheet-template-row"><span>Speed</span><span>{{defense_speed}}</span></div>{{/defense_speed}}
-    {{#dodge}}<div class="sheet-template-row"><span>Dodge</span><span>{{dodge}}</span></div>{{/dodge}}
-    {{#avoid}}<div class="sheet-template-row"><span>Avoid</span><span>{{avoid}}</span></div>{{/avoid}}
-    {{#defense}}<div class="sheet-template-row"><span>Defense</span><span>{{defense}}</span></div>{{/defense}}
-    {{#resistance}}<div class="sheet-template-row"><span>Resistance</span><span>{{resistance}}</span></div>{{/resistance}}
+    <div class="sheet-template-body">
+      {{#shared_roll}}<div class="sheet-template-row"><span>Roll (d100)</span><span>{{shared_roll}}</span></div>{{/shared_roll}}
+      <div class="sheet-template-panel sheet-template-panel-attack">
+        {{#attack_header}}<div class="sheet-template-section">{{attack_header}}</div>{{/attack_header}}
+        {{#attack_roll}}<div class="sheet-template-row"><span>Attack Roll</span><span>{{attack_roll}}</span></div>{{/attack_roll}}
+        {{#critical_roll}}<div class="sheet-template-row"><span>Critical Roll</span><span>{{critical_roll}}</span></div>{{/critical_roll}}
+        {{#damage}}<div class="sheet-template-row"><span>Damage</span><span>{{damage}}</span></div>{{/damage}}
+        {{#speed}}<div class="sheet-template-row"><span>Speed</span><span>{{speed}}</span></div>{{/speed}}
+        {{#weapon_range}}<div class="sheet-template-row"><span>Weapon Range</span><span>{{weapon_range}}</span></div>{{/weapon_range}}
+        {{#weapon_properties}}<div class="sheet-template-row"><span>Weapon Properties</span><span>{{weapon_properties}}</span></div>{{/weapon_properties}}
+        {{#item_properties}}<div class="sheet-template-row"><span>Item Properties</span><span>{{item_properties}}</span></div>{{/item_properties}}
+        {{#great_skill}}<div class="sheet-template-row"><span>Great Skill</span><span>{{great_skill}}</span></div>{{/great_skill}}
+      </div>
+      <div class="sheet-template-panel sheet-template-panel-defense">
+        {{#defense_header}}<div class="sheet-template-section">{{defense_header}}</div>{{/defense_header}}
+        {{#defense_speed}}<div class="sheet-template-row"><span>Speed</span><span>{{defense_speed}}</span></div>{{/defense_speed}}
+        {{#dodge}}<div class="sheet-template-row"><span>Dodge</span><span>{{dodge}}</span></div>{{/dodge}}
+        {{#avoid}}<div class="sheet-template-row"><span>Avoid</span><span>{{avoid}}</span></div>{{/avoid}}
+        {{#defense}}<div class="sheet-template-row"><span>Defense</span><span>{{defense}}</span></div>{{/defense}}
+        {{#resistance}}<div class="sheet-template-row"><span>Resistance</span><span>{{resistance}}</span></div>{{/resistance}}
+      </div>
+    </div>
   </div>
 </rolltemplate>
 


### PR DESCRIPTION
### Motivation
- Make the character name read and behave like a prominent header that fills its container for visual parity with builder blocks.
- Clean up Class Abilities and Combat Skills labels so punctuation no longer interferes with the new card/grid layout.
- Restore the repeating-section controls so users can `+Add` / `Modify` class and combat skills in the UI.
- Give the attack/defense roll template a cohesive visual treatment that matches the sheet (dark red frame, parchment nameplate, blue content panel, separate attack/defense panels).

### Description
- Stretched the name area by updating `.CharacterNameFlexItem` and `.CharacterNameHeader` and adding the `CharacterNameHeader` class to the name input in the HTML so the name fills the container edge (`Roll20/CharacterSheet/CharacterSheetV3.html`, `Roll20/CharacterSheet/CharacterSheetV3.css`).
- Removed inline `:` characters from labels in the Class Abilities and Combat Skills blocks and adjusted the label layout to use grid columns for label/value alignment (`Roll20/CharacterSheet/CharacterSheetV3.html`, `Roll20/CharacterSheet/CharacterSheetV3.css`).
- Re-enabled repeating controls for `repeating_classskillslist` and `repeating_combatskillslist` by making `.repcontrol` visible again and adding styled button rules so Add/Modify controls are usable and themed (`Roll20/CharacterSheet/CharacterSheetV3.css`).
- Reworked the `adelphiaattack` roll template markup to include a `.sheet-template-body` with `.sheet-template-panel` attack/defense sections and added themed CSS (dark red outer shell, parchment titleplate, blue inner body, parchment panels) to match the sheet's style (`Roll20/CharacterSheet/CharacterSheetV3.html`, `Roll20/CharacterSheet/CharacterSheetV3.css`).
- Misc: adjusted class and growth grid sizing/alignment, input sizing, and a small set of theming variables to harmonize the new card/grid presentation with the existing builder visuals (`Roll20/CharacterSheet/CharacterSheetV3.css`).

### Testing
- Ran `git diff --check` to verify whitespace/patch issues and it passed.
- Served the sheet locally with `python -m http.server 8123 --directory /workspace/Adelphia` to exercise the HTML/CSS and that succeeded.
- Captured an automated UI snapshot using Playwright with Firefox against `http://127.0.0.1:8123/Roll20/CharacterSheet/CharacterSheetV3.html` and the run completed and produced a screenshot artifact (passed).
- Attempted the Playwright run with Chromium which crashed in the environment (headless Chromium failed), so Firefox was used as the successful screenshot runner (Chromium: failed, Firefox: passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dc03d058832d8eb608304e370a94)