### PR TITLE
Fix temp-stat trigger countdown and tighten CharacterSheetV3 layout

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -73,6 +73,26 @@
   justify-content: center;
 }
 
+.CharacterHPFlexItem {
+  width: 100%;
+  max-width: 271px;
+  outline: auto;
+  outline-width: thin;
+  outline-style: solid;
+  padding: 5px;
+}
+
+.CharacterHPLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.CharacterHPInput {
+  width: 64px;
+  margin: 0;
+}
+
 .CharacterEquippedFlexItem {
   outline: auto;
   outline-width: thin;
@@ -146,20 +166,92 @@
 
 .CharacterQuirkSubgrid {
   display: grid;
-  grid-template-columns: fit-content 1fr fit-content;
+  grid-template-columns: 34px 220px 180px minmax(260px, 1fr);
   grid-template-rows: auto;
-  grid-auto-flow: column;
-  column-gap: 2%;
+  column-gap: 8px;
+  align-items: center;
   outline: none;
+}
+
+.CharacterQuirkSubgrid > .QuirkRollButton {
+  grid-column: 1;
+}
+
+.CharacterQuirkSubgrid > input[name="attr_quirk_name"] {
+  grid-column: 2;
+}
+
+.CharacterQuirkSubgrid > .QuirkStatDropdown {
+  grid-column: 3;
+}
+
+.CharacterQuirkSubgrid > input[name="attr_quirk_description"] {
+  grid-column: 4;
+}
+
+.QuirkStatDropdown {
+  width: 100%;
+}
+
+.QuirkRollButton {
+  width: 34px;
+  min-width: 34px;
+  padding: 3px 6px;
+}
+
+.QuirkRollButton:empty::before {
+  content: "🎲";
+}
+
+.AttackRiposteRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.AttackRiposteHeaderRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.AttackRiposteHeaderRow .PrimaryTitle {
+  margin: 0;
+}
+
+.AttackRiposteRollButton {
+  min-width: 34px;
+  padding: 3px 6px;
+}
+
+.CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_tempstatlist"] {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_tempstatlist"] > .repitem {
+  outline: auto;
+  outline-width: thin;
+  outline-style: solid;
+  padding: 6px;
+}
+
+.CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_tempstatlist"] {
+  display: block;
 }
 
 .CharacterTempStatAdjustmentSubgrid {
   display: grid;
-  grid-template-columns: 11% 26% 11% 46%;
-  grid-template-rows: auto;
-  grid-auto-flow: column;
-  column-gap: 2%;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 10px;
   outline: none;
+}
+
+.CharacterTempStatAdjustmentSubgrid .PrimaryLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 /*Weapons*/
@@ -877,4 +969,46 @@ button[type="action"]:hover {
 
 .sheet-rolltemplate-adelphiaattack .sheet-template-row > span:last-child {
   color: #1f2435;
+}
+
+
+/* Roll template: adelphiaquirk */
+.sheet-rolltemplate-adelphiaquirk {
+  border: 2px solid #c8a05a;
+  background: linear-gradient(155deg, #6f2b23 0%, #8a3a2e 40%, #4c1a17 100%);
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow: inset 0 0 0 1px rgba(233, 221, 186, 0.25);
+  color: #2b2521;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-title {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  color: #623313;
+  padding: 4px 8px;
+  font-weight: 700;
+  font-size: 1.1em;
+  margin-bottom: 8px;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-body {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  padding: 8px;
+  display: grid;
+  gap: 4px;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-row {
+  display: grid;
+  grid-template-columns: 170px 1fr;
+  column-gap: 8px;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-row > span:first-child {
+  font-weight: 700;
+  color: #623313;
 }

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -11,6 +11,10 @@
             <div class="CharacterTokenFlexItem"><img name="attr_character_token"/></div>
             <div class="CharacterDescriptionFlexItem"><textarea name="attr_character_notes" class="PrimaryNotesEntry" placeholder="Character Notes" data-i18n-place="sheet-CharacterNotesPlaceholder" ></textarea></div>
 
+            <div class="CharacterHPFlexItem">
+                <label class="PrimaryLabel CharacterHPLabel"><span data-i18n="HP-Full-Name">HP</span>: <input type="number" class="PrimaryEntry CharacterHPInput" name="attr_current_hp" value="0" min="0"> / <span name="attr_hp_stat_total"></span></label>
+            </div>
+
             <div class="CharacterEquippedFlexItem"> <!-- Weapon Selector -->
                 <h1 class="PrimaryTitle" data-i18n="weapon-title-u">Weapons</h1>
                 <fieldset class="repeating_weapons">
@@ -88,65 +92,57 @@
                     <h1 class="PrimaryTitle" data-i18n="quirks-title-u">Quirks</h1>
                     <fieldset class="repeating_quirklist">
                         <div class="CharacterQuirkSubgrid">
-                            <button type="roll" class="PrimaryButton" value="&{template:default} {{name=Test Attack}} {{attack=[[1d20]]}} {{damage=[[2d6]]}}" name="roll_QuirkCheck"></button>
+                            <button type="action" class="PrimaryButton QuirkRollButton" name="act_QuirkCheck"></button>
                             <input type="text" class="PrimaryEntry" name="attr_quirk_name" placeholder="Quirk Name Goes Here" data-i18n-place="sheet-CharacterQuirkPlaceholder"/>
-                            <select name="attr_quirk-stat" class="PrimaryDropdown">
+                            <select name="attr_quirk-stat" class="PrimaryDropdown QuirkStatDropdown">
                                 <option value="STR" selected="selected" data-i18n="STR-Full-Name">Strength</option>
                                 <option value="INT" selected="selected" data-i18n="INT-Full-Name">Intelligence</option>
                                 <option value="DEX" selected="selected" data-i18n="DEX-Full-Name">Dexterity</option>
                                 <option value="SPD" selected="selected" data-i18n="SPD-Full-Name">Speed</option>
-                                <option value="LUK" selected="selected" data-i18n="LUK-Full-Name">Luck</option>
                                 <option value="CON" selected="selected" data-i18n="CON-Full-Name">Constitution</option>
                                 <option value="WIS" selected="selected" data-i18n="WIS-Full-Name">Wisdom</option>
-                                <option value="MOV" selected="selected" data-i18n="MOV-Full-Name">Movement</option>
-                                <option value="MGT" selected="selected" data-i18n="MGT-Full-Name">Might</option>
-                                <option value="ACC" selected="selected" data-i18n="ACC-Full-Name">Accuracy</option>
-                                <option value="CRT" selected="selected" data-i18n="CRT-Full-Name">Critical</option>
-                                <option value="DGE" selected="selected" data-i18n="DGE-Full-Name">Dodge</option>
-                                <option value="AVD" selected="selected" data-i18n="AVD-Full-Name">Avoid</option>
-                                <option value="DEF" selected="selected" data-i18n="DEF-Full-Name">Defense</option>
-                                <option value="RES" selected="selected" data-i18n="RES-Full-Name">Resistance</option>
                             </select>
+                            <input type="text" class="PrimaryEntry" name="attr_quirk_description" placeholder="Quirk Description" data-i18n-place="sheet-CharacterQuirkDescriptionPlaceholder"/>
                         </div>
                     </fieldset>
                 </div>
                 <br>
-                <div class="CharacterSheetFlexObject"> <!-- Attacking Stats -->
-                    <h1 class="PrimaryTitle" data-i18n="Attack-title-u">Attack</h1>
-                    <button type="roll" class="PrimaryButton" name="roll_Attack" value="&{template:adelphiaattack} {{name=@{character_name} - Attack}} {{attack_header=Attack}} {{attack_roll=[[@{AttackAccuracy}-(1d100-1)]]}} {{critical_roll=[[@{AttackCritical}-(1d100-1)]]}} {{damage=@{AttackMight}}} {{speed=@{spd_stat_total}}} {{weapon_range=@{Equipped_Weapon_Range}}} {{weapon_properties=@{Equipped_Weapon_Notes}}} {{item_properties=@{Equipped_Item_Notes}}} {{great_skill=@{GreatSkillDescription}}} {{defense_header=Defense}} {{defense_speed=@{spd_stat_total}}} {{dodge=@{AttackDodge}}} {{avoid=@{AttackAvoid}}} {{defense=@{AttackDefense}}} {{resistance=@{AttackResistance}}}" data-i18n="trigger-button">Trigger</button>
-                    <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span><span>: </span><span name="attr_AttackMight"></span></label>
-                    <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span><span>: </span><span name="attr_AttackAccuracy"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span><span>: </span><span name="attr_AttackCritical"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span><span>: </span><span name="attr_AttackDodge"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span><span>: </span><span name="attr_AttackAvoid"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span><span>: </span><span name="attr_AttackDefense"></span></label>
-                    <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span><span>: </span><span name="attr_AttackResistance"></span></label>
-                </div>
-                <div class="CharacterSheetFlexObject"> <!-- Riposte Stats -->
-                    <h1 class="PrimaryTitle" data-i18n="Attack-Riposte-u">Riposte</h1>
-                    <button type="roll" class="PrimaryButton" name="roll_Riposte" value="&{template:adelphiaattack} {{name=@{character_name} - Riposte}} {{attack_header=Attack}} {{attack_roll=[[@{RiposteAccuracy}-(1d100-1)]]}} {{critical_roll=[[@{RiposteCritical}-(1d100-1)]]}} {{damage=@{RiposteMight}}} {{speed=@{spd_stat_total}}} {{weapon_range=@{Equipped_Weapon_Range}}} {{weapon_properties=@{Equipped_Weapon_Notes}}} {{item_properties=@{Equipped_Item_Notes}}} {{great_skill=@{GreatSkillDescription}}} {{defense_header=Defense}} {{defense_speed=@{spd_stat_total}}} {{dodge=@{RiposteDodge}}} {{avoid=@{RiposteAvoid}}} {{defense=@{RiposteDefense}}} {{resistance=@{RiposteResistance}}}" data-i18n="trigger-button">Trigger</button>
-                    <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span><span>: </span><span name="attr_RiposteMight"></span></label>
-                    <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span><span>: </span><span name="attr_RiposteAccuracy"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span><span>: </span><span name="attr_RiposteCritical"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span><span>: </span><span name="attr_RiposteDodge"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span><span>: </span><span name="attr_RiposteAvoid"></span><span>%</span></label>
-                    <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span><span>: </span><span name="attr_RiposteDefense"></span></label>
-                    <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span><span>: </span><span name="attr_RiposteResistance"></span></label>
+                <div class="AttackRiposteRow">
+                    <div class="CharacterSheetFlexObject"> <!-- Attacking Stats -->
+                        <div class="AttackRiposteHeaderRow">
+                            <button type="roll" class="PrimaryButton AttackRiposteRollButton" name="roll_Attack" value="&{template:adelphiaattack} {{name=@{character_name} - Attack}} {{attack_header=Attack}} {{attack_roll=[[@{AttackAccuracy}-(1d100-1)]]}} {{critical_roll=[[@{AttackCritical}-(1d100-1)]]}} {{damage=@{AttackMight}}} {{speed=@{spd_stat_total}}} {{weapon_range=@{Equipped_Weapon_Range}}} {{weapon_properties=@{Equipped_Weapon_Notes}}} {{item_properties=@{Equipped_Item_Notes}}} {{great_skill=@{GreatSkillDescription}}} {{defense_header=Defense}} {{defense_speed=@{spd_stat_total}}} {{dodge=@{AttackDodge}}} {{avoid=@{AttackAvoid}}} {{defense=@{AttackDefense}}} {{resistance=@{AttackResistance}}}"></button>
+                            <h1 class="PrimaryTitle" data-i18n="Attack-title-u">Attack</h1>
+                        </div>
+                        <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span><span>: </span><span name="attr_AttackMight"></span></label>
+                        <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span><span>: </span><span name="attr_AttackAccuracy"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span><span>: </span><span name="attr_AttackCritical"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span><span>: </span><span name="attr_AttackDodge"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span><span>: </span><span name="attr_AttackAvoid"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span><span>: </span><span name="attr_AttackDefense"></span></label>
+                        <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span><span>: </span><span name="attr_AttackResistance"></span></label>
+                    </div>
+                    <div class="CharacterSheetFlexObject"> <!-- Riposte Stats -->
+                        <div class="AttackRiposteHeaderRow">
+                            <button type="roll" class="PrimaryButton AttackRiposteRollButton" name="roll_Riposte" value="&{template:adelphiaattack} {{name=@{character_name} - Riposte}} {{attack_header=Attack}} {{attack_roll=[[@{RiposteAccuracy}-(1d100-1)]]}} {{critical_roll=[[@{RiposteCritical}-(1d100-1)]]}} {{damage=@{RiposteMight}}} {{speed=@{spd_stat_total}}} {{weapon_range=@{Equipped_Weapon_Range}}} {{weapon_properties=@{Equipped_Weapon_Notes}}} {{item_properties=@{Equipped_Item_Notes}}} {{great_skill=@{GreatSkillDescription}}} {{defense_header=Defense}} {{defense_speed=@{spd_stat_total}}} {{dodge=@{RiposteDodge}}} {{avoid=@{RiposteAvoid}}} {{defense=@{RiposteDefense}}} {{resistance=@{RiposteResistance}}}"></button>
+                            <h1 class="PrimaryTitle" data-i18n="Attack-Riposte-u">Riposte</h1>
+                        </div>
+                        <label class="PrimaryLabel"><span data-i18n="MGT-Full-Name">Might</span><span>: </span><span name="attr_RiposteMight"></span></label>
+                        <label class="PrimaryLabel"><span data-i18n="ACC-Full-Name">Accuracy</span><span>: </span><span name="attr_RiposteAccuracy"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="CRT-Full-Name">Critical</span><span>: </span><span name="attr_RiposteCritical"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="DGE-Full-Name">Dodge</span><span>: </span><span name="attr_RiposteDodge"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="AVD-Full-Name">Avoid</span><span>: </span><span name="attr_RiposteAvoid"></span><span>%</span></label>
+                        <label class="PrimaryLabel"><span data-i18n="DEF-Full-Name">Defense</span><span>: </span><span name="attr_RiposteDefense"></span></label>
+                        <label class="PrimaryLabel"><span data-i18n="RES-Full-Name">Resistance</span><span>: </span><span name="attr_RiposteResistance"></span></label>
+                    </div>
                 </div>
                 <br>
                 <div class="CharacterSheetFlexObject"> <!-- Temporary Stat Adjustment -->
                     <h1 class="PrimaryTitle" data-i18n="temp-stat-adj-title-u">Temp Stat Adjustment</h1>
                     <button type="action" class="PrimaryButton" name="act_temp-stats-start-of-turn" data-i18n="trigger-button">Trigger</button>
-                    <div class="CharacterTempStatAdjustmentSubgrid">
-                        <div class="PrimaryLabel"><label data-i18n="stat-change-column-change">Change</label></div>
-                        <div class="PrimaryLabel"><label data-i18n="stat-change-column-stat">Stat</label></div>
-                        <div class="PrimaryLabel"><label data-i18n="stat-change-column-turns">Turns</label></div>
-                        <div class="PrimaryLabel"><label data-i18n="stat-change-column-notes">Notes</label></div>
-                    </div>
                     <fieldset class="repeating_tempstatlist">
                         <div class="CharacterTempStatAdjustmentSubgrid">
-                            <input type="number" name="attr_adjustment-value" value="0" class="PrimaryEntry"/>
-                            <select name="attr_adjustment-stat" class="PrimaryDropdown">
+                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-change">Change</span><input type="number" name="attr_adjustment-value" value="0" class="PrimaryEntry"/></label>
+                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-stat">Stat</span><select name="attr_adjustment-stat" class="PrimaryDropdown">
                                 <option value="HP" selected="selected" data-i18n="HP-Full-Name">Hit Points</option>
                                 <option value="STR" selected="selected" data-i18n="STR-Full-Name">Strength</option>
                                 <option value="INT" selected="selected" data-i18n="INT-Full-Name">Intelligence</option>
@@ -163,9 +159,9 @@
                                 <option value="AVD" selected="selected" data-i18n="AVD-Full-Name">Avoid</option>
                                 <option value="DEF" selected="selected" data-i18n="DEF-Full-Name">Defense</option>
                                 <option value="RES" selected="selected" data-i18n="RES-Full-Name">Resistance</option>
-                            </select>
-                            <input type="number" name="attr_adjustment-turns" value="0" class="PrimaryEntry"/>
-                            <input type="text" name="attr_adjustment-notes" value="" class="PrimaryEntry"/>
+                            </select></label>
+                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-turns">Turns</span><input type="number" name="attr_adjustment-turns" value="0" class="PrimaryEntry"/></label>
+                            <label class="PrimaryLabel"><span data-i18n="stat-change-column-notes">Notes</span><input type="text" name="attr_adjustment-notes" value="" class="PrimaryEntry"/></label>
                         </div>
                     </fieldset>
                 </div>
@@ -1202,6 +1198,19 @@
   </div>
 </rolltemplate>
 
+<rolltemplate class="sheet-rolltemplate-adelphiaquirk">
+  <div class="sheet-template-container">
+    {{#name}}<div class="sheet-template-title">{{name}}</div>{{/name}}
+    <div class="sheet-template-body">
+      {{#roll}}<div class="sheet-template-row"><span>Roll (d100)</span><span>{{roll}}</span></div>{{/roll}}
+      {{#stat_used}}<div class="sheet-template-row"><span>Stat Used</span><span>{{stat_used}}</span></div>{{/stat_used}}
+      {{#difficulty_result}}<div class="sheet-template-row"><span>Difficulty Hit</span><span>{{difficulty_result}}</span></div>{{/difficulty_result}}
+      {{#critical_result}}<div class="sheet-template-row"><span>Critical</span><span>{{critical_result}}</span></div>{{/critical_result}}
+      {{#description}}<div class="sheet-template-row"><span>Description</span><span>{{description}}</span></div>{{/description}}
+    </div>
+  </div>
+</rolltemplate>
+
 <!-- use text/worker to submit. Use text/javascript to get syntax highlighting. -->
 <script type="text/worker">
 
@@ -1210,6 +1219,24 @@
   function d10() { return getRandomInt(9); };
   function d10d10() { return getRandomInt(9) + getRandomInt(9); };
   function d100() { return getRandomInt(99); };
+
+  const QuirkDifficultyTable = [
+    { name: "Trivial", bonus: 100 },
+    { name: "Easy", bonus: 75 },
+    { name: "Average", bonus: 50 },
+    { name: "Difficult", bonus: 25 },
+    { name: "Legendary", bonus: 0 },
+    { name: "Impossible", bonus: -25 }
+  ];
+
+  const QuirkStatAttributeMap = {
+    STR: "str_stat_total",
+    INT: "int_stat_total",
+    DEX: "dex_stat_total",
+    SPD: "spd_stat_total",
+    CON: "con_stat_total",
+    WIS: "wis_stat_total"
+  };
 
 /* Database List */
   const StatList = [
@@ -1802,6 +1829,65 @@
   StatList.forEach(stat => {
     on(`change:${stat}_growth_base change:${stat}_growth_bg`, function() {
         CalculateStats();
+    });
+  });
+
+  on("clicked:temp-stats-start-of-turn", function() {
+    getSectionIDs("repeating_tempstatlist", function(ids) {
+      if (!ids || ids.length === 0) { return; }
+      const turnAttrs = ids.map((id) => `repeating_tempstatlist_${id}_adjustment-turns`);
+      getAttrs(turnAttrs, function(values) {
+        const updates = {};
+        ids.forEach((id) => {
+          const key = `repeating_tempstatlist_${id}_adjustment-turns`;
+          const turns = Math.max(0, toNumber(values[key]));
+          updates[key] = Math.max(0, turns - 1);
+        });
+        setAttrs(updates);
+      });
+    });
+  });
+
+  on("clicked:repeating_quirklist", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute || !eventInfo.htmlAttributes || eventInfo.htmlAttributes.name !== "act_QuirkCheck") { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (!rowId) { return; }
+
+    const statKey = `repeating_quirklist_${rowId}_quirk-stat`;
+    const quirkNameKey = `repeating_quirklist_${rowId}_quirk_name`;
+    const quirkDescriptionKey = `repeating_quirklist_${rowId}_quirk_description`;
+
+    getAttrs(["character_name", "luk_stat_total", statKey, quirkNameKey, quirkDescriptionKey], function(values) {
+      const characterName = values.character_name || "Character";
+      const quirkName = values[quirkNameKey] || "Unnamed Quirk";
+      const quirkDescription = values[quirkDescriptionKey] || "-";
+      const statCode = values[statKey] || "STR";
+      const statAttrName = QuirkStatAttributeMap[statCode];
+
+      if (!statAttrName) { return; }
+
+      getAttrs([statAttrName], function(statValues) {
+        const statValue = toNumber(statValues[statAttrName]);
+        const lukValue = toNumber(values.luk_stat_total);
+        const roll = Math.floor(Math.random() * 100) + 1;
+
+        let difficultyResult = "No Tier Reached";
+        for (let i = QuirkDifficultyTable.length - 1; i >= 0; i -= 1) {
+          const threshold = QuirkDifficultyTable[i].bonus + statValue;
+          if (roll <= threshold) {
+            difficultyResult = QuirkDifficultyTable[i].name;
+            break;
+          }
+        }
+
+        const success = difficultyResult !== "No Tier Reached";
+        const isCritical = success && roll <= lukValue;
+
+        const rollTemplate = `&{template:adelphiaquirk} {{name=${characterName} - ${quirkName}}} {{roll=${roll}}} {{stat_used=${statCode} (${statValue})}} {{difficulty_result=${difficultyResult}}} {{critical_result=${isCritical ? "Yes" : "No"}}} {{description=${quirkDescription}}}`;
+        startRoll(rollTemplate, function(results) {
+          finishRoll(results.rollId, {});
+        });
+      });
     });
   });
 

--- a/Roll20/CharacterSheet/CharactersheetV3.json
+++ b/Roll20/CharacterSheet/CharactersheetV3.json
@@ -2,6 +2,7 @@
 	"__Note1": "The below are not captured by the auto-config, and are manually created. Copy-paste the entries from https://jsfiddle.net/c9w3673g/3/ to the second section.",
 	"sheet-CharacterNotesPlaceholder": "Character Notes",
 	"sheet-CharacterQuirkPlaceholder": "Quirk Name Goes Here",
+	"sheet-CharacterQuirkDescriptionPlaceholder": "Quirk Description",
     "sheet-CharacterDescriptionPlaceholder": "Here is a place to keep a fuller description of your character",
     "sheet-CharacterAlliesPlaceholder": "Here is a place to keep a description of the people and organizations you have a relationship with",
     "sheet-CharacterHistoryPlaceholder": "Here is a place to keep a character history",


### PR DESCRIPTION
### Motivation
- Restore expected countdown behavior for Temporary Stat Adjustments when the Trigger is pressed by fixing the sheetworker logic.  
- Visually match the HP field to other left-column boxed sections and keep the `HP: [current] / [max]` presentation.  
- Ensure Quirks render as a single-line row with a compact dice-only roll control and keep temp-stat repeating entries readable as two-column cards.

### Description
- Added a sheetworker handler for `clicked:temp-stats-start-of-turn` that obtains `repeating_tempstatlist` row IDs and decrements each `repeating_tempstatlist_{id}_adjustment-turns` value, clamping at zero before writing the updates with `setAttrs`.  
- Moved HP into its own `CharacterHPFlexItem` block in `CharacterSheetV3.html` and added boxed/padded styling in `CharacterSheetV3.css` via `.CharacterHPFlexItem`, `.CharacterHPLabel`, and `.CharacterHPInput`.  
- Tightened Quirk layout by making `.CharacterQuirkSubgrid` a four-column grid and assigning each child control to explicit columns, added `.QuirkRollButton` sizing and `:empty::before` dice fallback, and preserved the icon-only roll button pattern.  
- Converted temp-stat repeating entries to labeled fields (wrap inputs in `label` elements), ensured the repeating container is visible by setting `.repcontrol[data-groupname="repeating_tempstatlist"] { display: block; }`, and added card-like `.repitem` styling.  
- Introduced a new `adelphiaquirk` rolltemplate and client-side support: added `QuirkDifficultyTable` and `QuirkStatAttributeMap` constants and an `on("clicked:repeating_quirklist", ...)` handler that computes a d100 roll, evaluates difficulty tiers and critical checks, and calls `startRoll` with the new roll template.  
- Added a small localization entry `sheet-CharacterQuirkDescriptionPlaceholder` to `CharactersheetV3.json`.

### Testing
- Ran JSON validation with `python -m json.tool Roll20/CharacterSheet/CharactersheetV3.json` and it succeeded.  
- Searched for key identifiers with `rg -n "clicked:temp-stats-start-of-turn|CharacterHPFlexItem|CharacterQuirkSubgrid|repeating_tempstatlist"` and the expected entries were present.  
- Served the sheet locally with `python -m http.server 8123` and captured a visual verification screenshot using Playwright; Chromium launch crashed in this environment but the Firefox run succeeded and produced the screenshot.  
- No automated test failures were detected for the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993f2d1d090832db717544098281dbf)