### PR TITLE
Make quirk roll button match Attack/Riposte and align quirk fields

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -166,11 +166,33 @@
 
 .CharacterQuirkSubgrid {
   display: grid;
-  grid-template-columns: 34px 220px 180px minmax(260px, 1fr);
+  grid-template-columns: 34px 220px 180px minmax(0, 1fr);
   grid-template-rows: auto;
   column-gap: 8px;
+  row-gap: 4px;
   align-items: center;
   outline: none;
+}
+
+.CharacterQuirkSubgrid > .PrimaryEntry,
+.CharacterQuirkSubgrid > .PrimaryDropdown,
+.CharacterQuirkSubgrid > .PrimaryButton {
+  margin: 0;
+  min-height: 30px;
+  box-sizing: border-box;
+}
+
+.CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_quirklist"] {
+  display: grid;
+  gap: 6px;
+}
+
+.CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_quirklist"] .repitem {
+  margin: 0;
+}
+
+.CharacterSheetFlexObject > .repcontrol[data-groupname="repeating_quirklist"] {
+  margin-top: 6px;
 }
 
 .CharacterQuirkSubgrid > .QuirkRollButton {
@@ -187,20 +209,29 @@
 
 .CharacterQuirkSubgrid > input[name="attr_quirk_description"] {
   grid-column: 4;
+  width: 100%;
+  min-width: 0;
 }
 
 .QuirkStatDropdown {
   width: 100%;
+  min-width: 0;
 }
 
 .QuirkRollButton {
   width: 34px;
   min-width: 34px;
   padding: 3px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
-.QuirkRollButton:empty::before {
-  content: "🎲";
+.QuirkRollButton::before {
+  content: "t";
+  font-family: "dicefontd20";
+  font-size: 1rem;
 }
 
 .AttackRiposteRow {


### PR DESCRIPTION
### Motivation
- Fix vertical misalignment between the quirk `name` input, stat dropdown, and roll button so the quirk row visuals match other controls. 
- Make the quirk roll button visually identical to the Attack/Riposte dice button (centered dice glyph, compact footprint). 
- Preserve the description field stretching and ensure repeating quirk rows stack cleanly without overlap.

### Description
- Modified `Roll20/CharacterSheet/CharacterSheetV3.css` to change the quirk grid to `minmax(0, 1fr)` and add `row-gap: 4px` so descriptions consume remaining space and rows gap properly. 
- Normalized control sizing by adding `.CharacterQuirkSubgrid > .PrimaryEntry, .PrimaryDropdown, .PrimaryButton { margin: 0; min-height: 30px; box-sizing: border-box; }` to align the `name`, dropdown and `button`. 
- Added repeating-list layout rules under `.CharacterSheetFlexObject > .repcontainer[data-groupname="repeating_quirklist"]` and related selectors to prevent overlapping repeating rows. 
- Kept the description input `width: 100%; min-width: 0;` and set `.QuirkStatDropdown { min-width: 0; }` to allow proper shrinking. 
- Restyled `.QuirkRollButton` to use `display: inline-flex; align-items: center; justify-content: center; line-height: 1;` and replaced the previous emoji pseudo-element with a dice glyph via `.QuirkRollButton::before { content: "t"; font-family: "dicefontd20"; font-size: 1rem; }` so it matches the Attack/Riposte treatment.

### Testing
- Served the sheet locally with `python3 -m http.server 8123` and captured a Playwright screenshot of `http://127.0.0.1:8123/Roll20/CharacterSheet/CharacterSheetV3.html`, which generated an artifact successfully. (succeeded)
- Verified the CSS diff with `git diff -- Roll20/CharacterSheet/CharacterSheetV3.css` and confirmed only that file changed. (succeeded)
- Ran `git status --short` and committed the CSS update. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699409c37c18832da52da086923b9cd1)