### PR TITLE
Adjust adelphiaquirk layout and show quirk difficulty bonuses in labels

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -1082,19 +1082,41 @@ button[type="action"]:hover {
 .sheet-rolltemplate-adelphiaquirk .sheet-template-body {
   border: 2px solid #c8a05a;
   border-radius: 6px;
-  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  background: linear-gradient(145deg, #445ca4 0%, #354c8e 100%);
   padding: 8px;
   display: grid;
-  gap: 4px;
+  gap: 8px;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-panel {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  padding: 6px;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-section {
+  border-bottom: 1px solid rgba(98, 51, 19, 0.35);
+  margin-bottom: 6px;
+  padding-bottom: 2px;
+  font-weight: 700;
+  color: #623313;
+  text-transform: uppercase;
 }
 
 .sheet-rolltemplate-adelphiaquirk .sheet-template-row {
   display: grid;
-  grid-template-columns: 170px 1fr;
+  grid-template-columns: 1fr 1fr;
   column-gap: 8px;
+  align-items: start;
+  margin-bottom: 2px;
 }
 
 .sheet-rolltemplate-adelphiaquirk .sheet-template-row > span:first-child {
   font-weight: 700;
   color: #623313;
+}
+
+.sheet-rolltemplate-adelphiaquirk .sheet-template-description {
+  color: #1f2435;
 }

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -1210,11 +1210,18 @@
   <div class="sheet-template-container">
     {{#name}}<div class="sheet-template-title">{{name}}</div>{{/name}}
     <div class="sheet-template-body">
-      {{#roll}}<div class="sheet-template-row"><span>Roll (d100)</span><span>{{roll}}</span></div>{{/roll}}
-      {{#stat_used}}<div class="sheet-template-row"><span>Stat Used</span><span>{{stat_used}}</span></div>{{/stat_used}}
-      {{#difficulty_result}}<div class="sheet-template-row"><span>Difficulty Hit</span><span>{{difficulty_result}}</span></div>{{/difficulty_result}}
-      {{#critical_result}}<div class="sheet-template-row"><span>Critical</span><span>{{critical_result}}</span></div>{{/critical_result}}
-      {{#description}}<div class="sheet-template-row"><span>Description</span><span>{{description}}</span></div>{{/description}}
+      <div class="sheet-template-panel">
+        {{#roll}}<div class="sheet-template-row"><span>Roll (d100)</span><span>{{roll}}</span></div>{{/roll}}
+        {{#stat_used}}<div class="sheet-template-row"><span>Stat Used</span><span>{{stat_used}}</span></div>{{/stat_used}}
+        {{#difficulty_result}}<div class="sheet-template-row"><span>Difficulty Hit</span><span>{{difficulty_result}}</span></div>{{/difficulty_result}}
+        {{#critical_result}}<div class="sheet-template-row"><span>Critical</span><span>{{critical_result}}</span></div>{{/critical_result}}
+      </div>
+      {{#description}}
+      <div class="sheet-template-panel">
+        <div class="sheet-template-section">Description</div>
+        <div class="sheet-template-description">{{description}}</div>
+      </div>
+      {{/description}}
     </div>
   </div>
 </rolltemplate>
@@ -1229,12 +1236,12 @@
   function d100() { return getRandomInt(99); };
 
   const QuirkDifficultyTable = [
-    { name: "Trivial", bonus: 100 },
-    { name: "Easy", bonus: 75 },
-    { name: "Average", bonus: 50 },
-    { name: "Difficult", bonus: 25 },
-    { name: "Legendary", bonus: 0 },
-    { name: "Impossible", bonus: -25 }
+    { name: "Trivial (100)", bonus: 100 },
+    { name: "Easy (75)", bonus: 75 },
+    { name: "Average (50)", bonus: 50 },
+    { name: "Difficult (25)", bonus: 25 },
+    { name: "Legendary (0)", bonus: 0 },
+    { name: "Impossible (-25)", bonus: -25 }
   ];
 
   const QuirkStatAttributeMap = {


### PR DESCRIPTION
### Motivation
- Fix the adelphiaquirk roll template layout to better align label/value columns and improve visual grouping of fields. 
- Make quirk difficulty labels explicit by showing the numeric `bonus` value alongside each difficulty name for clearer UX.

### Description
- Modified `Roll20/CharacterSheet/CharacterSheetV3.css` to change the top-island label/value split from `grid-template-columns: 170px 1fr` to `grid-template-columns: 1fr 1fr`, added `.sheet-template-panel` and `.sheet-template-section` styles, tightened spacing, and added a `.sheet-template-description` color. 
- Updated `Roll20/CharacterSheet/CharacterSheetV3.html` layout for the `sheet-rolltemplate-adelphiaquirk` roll template to wrap related rows in panel containers and move the description into its own section. 
- Updated the `QuirkDifficultyTable` in the embedded script to use labels that include their bonus values (for example `Trivial (100)` through `Impossible (-25)`) while preserving the numeric `bonus` properties used by logic.

### Testing
- Ran `git diff --check` and it passed. 
- Started a local static server with `python -m http.server` and captured a full-page screenshot of `Roll20/CharacterSheet/CharacterSheetV3.html` using a Playwright script, producing the artifact `artifacts/quirk-difficulty-table-update.png` without errors. 
- Confirmed the modified files include the intended CSS, HTML, and `QuirkDifficultyTable` label updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699412ec2f28832d84d0a6a5f8f5aa1c)