### PR TITLE
Fix skills toggle selectors and restore section header underline in CharacterSheetV3

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -460,16 +460,50 @@
   width: 100%;
 }
 
+.SectionTitleWithToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.SectionTitleWithToggle .PrimaryTitle {
+  margin: 0;
+  flex: 1;
+}
+
 .charsheet .sheet-classskillslist-Check {
   appearance: none;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.charsheet .sheet-classskillslist-Check:checked::before {
-  content: ' ↴ ';
+.charsheet .sheet-classskillslist-ToggleButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-width: 34px;
+  height: 24px;
+  border: 1px solid #f2d79e;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #3f64bf 0%, #2d458a 100%);
+  color: #fffdf5;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(244, 232, 203, 0.35);
+  margin: 0;
+  cursor: pointer;
 }
 
-.charsheet .sheet-classskillslist-Check:not(:checked)::before {
-  content: ' → ';
+.charsheet .sheet-classskillslist-ToggleButton::before {
+  content: '→';
+}
+
+.charsheet .sheet-classskillslist-Check:checked + .SectionTitleWithToggle .sheet-classskillslist-ToggleButton::before {
+  content: '↴';
 }
 
 .sheet-classskillslist-Short,
@@ -485,14 +519,36 @@
 /*Skills*/
 .charsheet .sheet-combatskillslist-Check {
   appearance: none;
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.charsheet .sheet-combatskillslist-Check:checked::before {
-  content: ' ↴ ';
+.charsheet .sheet-combatskillslist-ToggleButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  min-width: 34px;
+  height: 24px;
+  border: 1px solid #f2d79e;
+  border-radius: 4px;
+  background: linear-gradient(180deg, #3f64bf 0%, #2d458a 100%);
+  color: #fffdf5;
+  font-weight: 700;
+  line-height: 1;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(244, 232, 203, 0.35);
+  margin: 0;
+  cursor: pointer;
 }
 
-.charsheet .sheet-combatskillslist-Check:not(:checked)::before {
-  content: ' → ';
+.charsheet .sheet-combatskillslist-ToggleButton::before {
+  content: '→';
+}
+
+.charsheet .sheet-combatskillslist-Check:checked + .SectionTitleWithToggle .sheet-combatskillslist-ToggleButton::before {
+  content: '↴';
 }
 
 .sheet-combatskillslist-Short,

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -663,8 +663,11 @@
                     </div>
                 </div>
                 <div class="CharacterSheetFlexObject"> <!-- Class Abilities-->
-                    <h1 class="PrimaryTitle" data-i18n="Levelup-Class-Skills-title-u">Class Abilities</h1>
-                    <input type="checkbox" class="sheet-classskillslist-Check" name="attr_classskillslist-Check" value="0" />
+                    <input type="checkbox" id="classskillslist-toggle" class="sheet-classskillslist-Check" name="attr_classskillslist-Check" value="0" />
+                    <div class="SectionTitleWithToggle">
+                        <h1 class="PrimaryTitle" data-i18n="Levelup-Class-Skills-title-u">Class Abilities</h1>
+                        <label for="classskillslist-toggle" class="sheet-classskillslist-ToggleButton"></label>
+                    </div>
                     <div class="sheet-classskillslist-Short">
                         <fieldset class="repeating_classskillslist">
                             <label class="PrimaryLabel"><span data-i18n="Class-Skill-Name">Skill</span> <select name="attr_ClassSkill">
@@ -702,9 +705,12 @@
             </div>
             <div class="SheetPageSkills"> <!-- Character Skills Creation-->
                 <div class="CharacterSheetFlexObject"> <!-- Combat Skills-->
-                    <h1 class="PrimaryTitle" data-i18n="Levelup-Combat-Skills-title-u">Combat Skills</h1>
+                    <input type="checkbox" id="combatskillslist-toggle" class="sheet-combatskillslist-Check" name="attr_combatskillslist-Check" value="0" />
+                    <div class="SectionTitleWithToggle">
+                        <h1 class="PrimaryTitle" data-i18n="Levelup-Combat-Skills-title-u">Combat Skills</h1>
+                        <label for="combatskillslist-toggle" class="sheet-combatskillslist-ToggleButton"></label>
+                    </div>
                     <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Points-Available">Skill Points</span> <span name="attr_CombatSkillPointsAvailable"></span></label>
-                    <input type="checkbox" class="sheet-combatskillslist-Check" name="attr_combatskillslist-Check" value="0" />
                     <div class="sheet-combatskillslist-Short">
                         <fieldset class="repeating_combatskillslist">
                             <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">


### PR DESCRIPTION
### Motivation
- The previous change moved the visibility checkbox into a nested header wrapper which broke the sibling combinator rules that control showing the short/long skill lists. 
- The header underline (pin line) was removed during the refactor and needs to be restored so section headers visually match the rest of the sheet. 

### Description
- Moved the real checkbox inputs for the Class and Combat skills to sit before the header/content blocks and added inline label buttons (`<label for="..." class="...-ToggleButton">`) inside the `.SectionTitleWithToggle` so the visible toggle remains next to the title while the checkbox remains the state source. 
- Added `.SectionTitleWithToggle` CSS (flex layout and spacing), restored `PrimaryTitle` behavior by using `flex: 1` so the underline/pinning line spans the header, and visually hid the native checkbox with absolute positioning and `opacity: 0`. 
- Introduced `.sheet-*-ToggleButton` styling to replicate the blue primary-button look and updated the checked-state selectors to drive arrow glyphs on the visible label while keeping the original `.sheet-*-Check:checked ~ .sheet-*-Long` / `.sheet-*-Check:checked ~ .sheet-*-Short` visibility rules functional again. 

### Testing
- Inspected the updated HTML/CSS diff to confirm the checkbox is positioned before the content blocks and the label toggle is in the header, which succeeded. 
- Served the sheet locally using `python3 -m http.server 8000` and validated the page loaded successfully. 
- Captured a visual verification screenshot using a Playwright script against `http://127.0.0.1:8000/Roll20/CharacterSheet/CharacterSheetV3.html` to confirm the toggles and header underline render and toggle state glyphs update, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996bef13e54832db1167ca4d1dcfbcb)