### PR TITLE
Return binary combat skill results and align Great Skill activation to `1d100-1`

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -263,6 +263,23 @@
   font-size: 1rem;
 }
 
+.CombatSkillRollButton {
+  width: 34px;
+  min-width: 34px;
+  padding: 3px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  margin-bottom: 6px;
+}
+
+.CombatSkillRollButton::before {
+  content: "t";
+  font-family: "dicefontd20";
+  font-size: 1rem;
+}
+
 .AttackRiposteRow {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1152,6 +1169,69 @@ button[type="action"]:hover {
   margin-bottom: 4px;
 }
 
+
+/* Roll template: adelphiacombatskill */
+.sheet-rolltemplate-adelphiacombatskill {
+  border: 2px solid #c8a05a;
+  background: linear-gradient(155deg, #6f2b23 0%, #8a3a2e 40%, #4c1a17 100%);
+  border-radius: 8px;
+  padding: 8px;
+  box-shadow: inset 0 0 0 1px rgba(233, 221, 186, 0.25);
+  color: #2b2521;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-title {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  color: #623313;
+  padding: 4px 8px;
+  font-weight: 700;
+  font-size: 1.1em;
+  margin-bottom: 8px;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-body {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #445ca4 0%, #354c8e 100%);
+  padding: 8px;
+  display: grid;
+  gap: 8px;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-panel {
+  border: 2px solid #c8a05a;
+  border-radius: 6px;
+  background: linear-gradient(145deg, #f8f2dc 0%, #e7d9b3 100%);
+  padding: 6px;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-section {
+  border-bottom: 1px solid rgba(98, 51, 19, 0.35);
+  margin-bottom: 6px;
+  padding-bottom: 2px;
+  font-weight: 700;
+  color: #623313;
+  text-transform: uppercase;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 8px;
+  align-items: start;
+  margin-bottom: 2px;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-row > span:first-child {
+  font-weight: 700;
+  color: #623313;
+}
+
+.sheet-rolltemplate-adelphiacombatskill .sheet-template-description {
+  color: #1f2435;
+}
 
 /* Roll template: adelphiaquirk */
 .sheet-rolltemplate-adelphiaquirk {

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -713,6 +713,7 @@
                     <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Points-Available">Skill Points</span> <span name="attr_CombatSkillPointsAvailable"></span></label>
                     <div class="sheet-combatskillslist-Short">
                         <fieldset class="repeating_combatskillslist">
+                            <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
                             <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
@@ -752,6 +753,7 @@
                     </div>
                     <div class="sheet-combatskillslist-Long">
                         <fieldset class="repeating_combatskillslist">
+                            <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
                             <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
@@ -1045,6 +1047,19 @@
         {{#avoid}}<div class="sheet-template-row"><span>Avoid</span><span>{{avoid}}</span></div>{{/avoid}}
         {{#defense}}<div class="sheet-template-row"><span>Defense</span><span>{{defense}}</span></div>{{/defense}}
         {{#resistance}}<div class="sheet-template-row"><span>Resistance</span><span>{{resistance}}</span></div>{{/resistance}}
+      </div>
+    </div>
+  </div>
+</rolltemplate>
+
+<rolltemplate class="sheet-rolltemplate-adelphiacombatskill">
+  <div class="sheet-template-container">
+    {{#name}}<div class="sheet-template-title">{{name}}</div>{{/name}}
+    <div class="sheet-template-body">
+      <div class="sheet-template-panel">
+        {{#stat_check}}<div class="sheet-template-row"><span>Stat Check</span><span>{{stat_check}}</span></div>{{/stat_check}}
+        {{#effect}}<div class="sheet-template-section">Effect</div><div class="sheet-template-description">{{effect}}</div>{{/effect}}
+        {{#description}}<div class="sheet-template-section">Description</div><div class="sheet-template-description">{{description}}</div>{{/description}}
       </div>
     </div>
   </div>
@@ -1477,14 +1492,14 @@
 
     const baseExpression = `[[@{${selected.base}}+@{${selected.weapon}}]]`;
     const multiplier = statData.multiplier;
-    let thresholdExpression = `floor(${baseExpression}) + 1`;
+    let thresholdExpression = `floor(${baseExpression})`;
     if (multiplier !== 1) {
       thresholdExpression = (multiplier === 0.5)
-        ? `floor(${baseExpression}/2) + 1`
-        : `floor(${baseExpression}*${multiplier}) + 1`;
+        ? `floor(${baseExpression}/2)`
+        : `floor(${baseExpression}*${multiplier})`;
     }
 
-    return `[[1d100<[[${thresholdExpression}]]]]`;
+    return `[[ (1d100-1) < [[${thresholdExpression}]] ]]`;
   }
 
   function updateGreatSkillDescription() {
@@ -2095,6 +2110,40 @@
 
   on("change:repeating_tempstatlist:adjustment-value change:repeating_tempstatlist:adjustment-stat change:repeating_tempstatlist:adjustment-turns", function() {
     RefreshTempAdjustments();
+  });
+
+  on("clicked:repeating_combatskillslist", function(eventInfo) {
+    if (!eventInfo || !eventInfo.sourceAttribute || !eventInfo.htmlAttributes || eventInfo.htmlAttributes.name !== "act_CombatSkillCheck") { return; }
+    const rowId = eventInfo.sourceAttribute.split("_")[2];
+    if (!rowId) { return; }
+
+    const statKey = `repeating_combatskillslist_${rowId}_StatCombatSkillSelector`;
+    const skillNameKey = `repeating_combatskillslist_${rowId}_CombatSkill`;
+    const effectKey = `repeating_combatskillslist_${rowId}_CombatSkillEffect`;
+    const descriptionKey = `repeating_combatskillslist_${rowId}_CombatSkillDescription`;
+
+    getAttrs(["character_name", statKey, skillNameKey, effectKey, descriptionKey], function(values) {
+      const characterName = values.character_name || "Character";
+      const skillName = values[skillNameKey] || "Unnamed Skill";
+      const effect = values[effectKey] || "-";
+      const description = values[descriptionKey] || "-";
+      const statCode = values[statKey] || "STR";
+      const statAttrName = QuirkStatAttributeMap[statCode];
+
+      if (!statAttrName) { return; }
+
+      getAttrs([statAttrName], function(statValues) {
+        const statValue = toNumber(statValues[statAttrName]);
+        const rollPenalty = Math.floor(Math.random() * 100);
+        const statCheck = statValue - rollPenalty;
+        const statCheckResult = statCheck >= 0 ? 1 : 0;
+
+        const rollTemplate = `&{template:adelphiacombatskill} {{name=${characterName} - ${skillName}}} {{stat_check=${statCheckResult}}} {{effect=${effect}}} {{description=${description}}}`;
+        startRoll(rollTemplate, function(results) {
+          finishRoll(results.rollId, {});
+        });
+      });
+    });
   });
 
   on("clicked:repeating_quirklist", function(eventInfo) {


### PR DESCRIPTION
### Motivation
- Make combat-skill checks emit a binary success value (`1`/`0`) like the Great Skill Activation test instead of printing the arithmetic expression. 
- Correct Great Skill activation semantics so the activation comparison uses the sheet's `0..99` roll basis (`1d100-1`) and remove the prior `+ 1` threshold offset.

### Description
- Changed `getGreatSkillActivationRoll` to remove the previous `+ 1` offset and to generate comparisons against `(1d100-1)` so thresholds align with `0..99` rolls. 
- Added a click handler for `clicked:repeating_combatskillslist` that listens for the `act_CombatSkillCheck` action, computes `stat - (1d100-1)`, converts the result to a binary `1` (success) or `0` (failure), and emits that value as `stat_check` in the new `adelphiacombatskill` roll template.
- Injected the `act_CombatSkillCheck` action button into the `repeating_combatskillslist` rows (short and long views) and added the `adelphiacombatskill` rolltemplate markup to the sheet HTML. 
- Added CSS for `.CombatSkillRollButton` and styling for `.sheet-rolltemplate-adelphiacombatskill` so the button and the roll template match existing visuals.

### Testing
- Ran `git diff --check` which completed with no issues. 
- Served the sheet with `python -m http.server 8000` and captured a Playwright-rendered screenshot for visual verification, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989562708c832db4259f8ef4b27845)