### PR TITLE
Align combat skill dropdown with stat/weapon columns

### DIFF
--- a/Roll20/CharacterSheet/CharacterSheetV3.css
+++ b/Roll20/CharacterSheet/CharacterSheetV3.css
@@ -263,6 +263,24 @@
   font-size: 1rem;
 }
 
+.CombatSkillHeaderRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 34px;
+  column-gap: 6px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.CombatSkillHeaderRow .PrimaryLabel {
+  display: grid;
+  grid-template-columns: 115px minmax(0, 1fr);
+  align-items: center;
+  column-gap: 8px;
+  width: 100%;
+  min-width: 0;
+  margin-bottom: 0 !important;
+}
+
 .CombatSkillRollButton {
   width: 34px;
   min-width: 34px;
@@ -271,7 +289,7 @@
   align-items: center;
   justify-content: center;
   line-height: 1;
-  margin-bottom: 6px;
+  margin-bottom: 0;
 }
 
 .CombatSkillRollButton::before {

--- a/Roll20/CharacterSheet/CharacterSheetV3.html
+++ b/Roll20/CharacterSheet/CharacterSheetV3.html
@@ -713,8 +713,8 @@
                     <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Points-Available">Skill Points</span> <span name="attr_CombatSkillPointsAvailable"></span></label>
                     <div class="sheet-combatskillslist-Short">
                         <fieldset class="repeating_combatskillslist">
-                            <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
+                            <div class="CombatSkillHeaderRow">
+                                <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
                                 <option value="Buckler" selected="selected" data-i18n="Combat-Skill-Buckler">Buckler</option>
@@ -749,12 +749,15 @@
                                 <option value="Weapon Mastery 2" selected="selected" data-i18n="Combat-Skill-Weapon Mastery 2">Weapon Mastery 2</option>
                                 <option value="Weapon Mastery 3" selected="selected" data-i18n="Combat-Skill-Weapon Mastery 3">Weapon Mastery 3</option>
                                 </select>
+                                </label>
+                                <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
+                            </div>
                         </fieldset>
                     </div>
                     <div class="sheet-combatskillslist-Long">
                         <fieldset class="repeating_combatskillslist">
-                            <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
-                            <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
+                            <div class="CombatSkillHeaderRow">
+                                <label class="PrimaryLabel"><span data-i18n="Combat-Skill-Name">Skill</span> <select name="attr_CombatSkill">
                                 <option value="Advance" selected="selected" data-i18n="Combat-Skill-Advance">Advance</option>
                                 <option value="Bold" selected="selected" data-i18n="Combat-Skill-Bold">Bold</option>
                                 <option value="Buckler" selected="selected" data-i18n="Combat-Skill-Buckler">Buckler</option>
@@ -789,7 +792,9 @@
                                 <option value="Weapon Mastery 2" selected="selected" data-i18n="Combat-Skill-Weapon Mastery 2">Weapon Mastery 2</option>
                                 <option value="Weapon Mastery 3" selected="selected" data-i18n="Combat-Skill-Weapon Mastery 3">Weapon Mastery 3</option>
                                 </select>
-                            </label>
+                                </label>
+                                <button type="action" class="PrimaryButton CombatSkillRollButton" name="act_CombatSkillCheck"></button>
+                            </div>
                             <input type="hidden" class="StatCombatSkillSelectorDisplay" name="attr_StatCombatSkillSelectorDisplay" value="0" />
                             <label class="PrimaryLabel"><span data-i18n="stat-change-column-stat">Stat</span> <select name="attr_StatCombatSkillSelector">
                                 <option value="STR" selected="selected" data-i18n="STR-Full-Name">Strength</option>


### PR DESCRIPTION
### Motivation
- Ensure the combat skill dropdown lines up with the same column used by Stat and Weapon selectors so fields align visually across rows.
- Keep the roll/dice button visually on the far right while preventing it from shifting the dropdown column alignment.
- Apply the alignment to both compact and expanded (`short` and `long`) combat-skill rows for consistent layout.

### Description
- Converted `.CombatSkillHeaderRow` to a two-column grid with a flexible content column and a fixed 34px dice button column via CSS changes in `Roll20/CharacterSheet/CharacterSheetV3.css`.
- Updated `.CombatSkillHeaderRow .PrimaryLabel` to use the same `115px + flexible` two-column label grid pattern used by other stat/weapon rows so the dropdown lines up with those columns.
- Moved the `button[name="act_CombatSkillCheck"]` into a new `.CombatSkillHeaderRow` wrapper in both the short and long `repeating_combatskillslist` sections in `Roll20/CharacterSheet/CharacterSheetV3.html` so the button sits in the fixed right column.
- Adjusted `.CombatSkillRollButton` spacing to remove bottom margin so it vertically aligns with the dropdown.

### Testing
- Inspected the CSS diff to confirm `.CombatSkillHeaderRow` and `.PrimaryLabel` layout updates were applied (success).
- Served the HTML and captured a Playwright screenshot to visually validate that the combat skill dropdown aligns with the Stat and Weapon columns (artifact `artifacts/combat-skill-column-alignment.png`, success).
- Verified the updated HTML fragment for both short and long repeating rows to confirm the roll button was moved into the new header wrapper (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a34656fc832d9e31a3eb91d618b7)